### PR TITLE
fix unmatched request errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.2 (2020-10-07) brian123zx
+
+- fix errors not throwing when there are unmatched requests
+
 ## 1.0.1 (2019-07-03) benjroy
 
 - fix .npm ignore so it publishes the `src/` directory

--- a/src/createNockFixturesTestWrapper.js
+++ b/src/createNockFixturesTestWrapper.js
@@ -29,9 +29,7 @@ function createNockFixturesTestWrapper(options = {}) {
       );
     },
     unmatchedErrorMessage = unmatchedRequests =>
-      `unmatched requests not allowed (found ${
-        unmatchedRequests.length
-      }). Record fixtures and try again.`,
+      `unmatched requests not allowed (found ${unmatchedRequests}). Record fixtures and try again.`,
   } = options;
 
   const fixtureDir = () =>
@@ -114,6 +112,8 @@ function createNockFixturesTestWrapper(options = {}) {
       }
     }
 
+    const unmatchedLength = unmatched.length;
+
     // full cleanup
     nock.emitter.removeListener(NOCK_NO_MATCH_EVENT, handleUnmatchedRequest);
     unmatched = [];
@@ -121,14 +121,14 @@ function createNockFixturesTestWrapper(options = {}) {
     nock.enableNetConnect();
 
     // report about unmatched requests
-    if (unmatched.length) {
+    if (unmatchedLength) {
       if (isLockdownMode()) {
         throw new Error(
-          `${logNamePrefix}: ${mode}: ${unmatchedErrorMessage(unmatched)}`
+          `${logNamePrefix}: ${mode}: ${unmatchedErrorMessage(unmatchedLength)}`
         );
       } else if (isDryrunMode()) {
         console.warn( // eslint-disable-line no-console,prettier/prettier
-          `${logNamePrefix}: ${mode}: ${unmatched.length} unmatched requests`
+          `${logNamePrefix}: ${mode}: ${unmatchedLength} unmatched requests`
         );
       }
     }


### PR DESCRIPTION
It looks like `unmatched` is cleared right before its length is checked, so errors and warnings will never fire when there are unmatched requests. This PR saves the length of the array before it's reset so it can be checked later on.