### PR TITLE
include `fileFixturepath` in `unmatchedErrorMessage` call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.0.3 (2020-10-08) brian123zx
+## 1.1.0 (2020-10-09) brian123zx
 
 - When nocks encounters a number of unmatched requests, the error function it calls now includes the path it expects to find the nock file at.
 - Fixes a bug introduced in v1.0.2 where the first argument to `unmatchedErrorMessage` was the length of the unmatched request array instead of the array itself

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.0.3 (2020-10-08) brian123zx
+
+- When nocks encounters a number of unmatched requests, the error function it calls now includes the path it expects to find the nock file at.
+- Fixes a bug introduced in v1.0.2 where the first argument to `unmatchedErrorMessage` was the length of the unmatched request array instead of the array itself
+
 ## 1.0.2 (2020-10-07) brian123zx
 
 - fix errors not throwing when there are unmatched requests

--- a/README.md
+++ b/README.md
@@ -31,10 +31,10 @@ optionally, the error message that is thrown in `lockdown` mode can be configure
 const createJestNockFixturesTestWrapper = require('@nerdwallet/jest-nock-fixtures');
 
 createJestNockFixturesTestWrapper({
-  unmatchedErrorMessage: reqs =>
+  unmatchedErrorMessage: (reqs, fixtureFilepath) =>
     `unmatched requests not allowed (found ${
       reqs.length
-    }).\n\nRun \`npm run test:record\` to update fixtures, and try again.`    
+    }).\n\nRun \`npm run test:record\` to update fixtures, and try again.`
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ optionally, the error message that is thrown in `lockdown` mode can be configure
 const createJestNockFixturesTestWrapper = require('@nerdwallet/jest-nock-fixtures');
 
 createJestNockFixturesTestWrapper({
-  unmatchedErrorMessage: (reqs, fixtureFilepath) =>
+  unmatchedErrorMessage: (reqs, { fixtureFilepath }) =>
     `unmatched requests not allowed (found ${
       reqs.length
     }).\n\nRun \`npm run test:record\` to update fixtures, and try again.`

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.2",
+  "version": "1.0.3",
   "name": "@nerdwallet/jest-nock-fixtures",
   "description": "jest-nock-fixtures",
   "author": "benjroy <ballen@nerdwallet.com>",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.3",
+  "version": "1.1.0",
   "name": "@nerdwallet/jest-nock-fixtures",
   "description": "jest-nock-fixtures",
   "author": "benjroy <ballen@nerdwallet.com>",

--- a/src/createNockFixturesTestWrapper.js
+++ b/src/createNockFixturesTestWrapper.js
@@ -114,7 +114,7 @@ function createNockFixturesTestWrapper(options = {}) {
       }
     }
 
-    const unmatchedLength = unmatched.length;
+    const cachedUnmatched = unmatched;
 
     // full cleanup
     nock.emitter.removeListener(NOCK_NO_MATCH_EVENT, handleUnmatchedRequest);
@@ -123,17 +123,19 @@ function createNockFixturesTestWrapper(options = {}) {
     nock.enableNetConnect();
 
     // report about unmatched requests
-    if (unmatchedLength) {
+    if (cachedUnmatched.length) {
       if (isLockdownMode()) {
         throw new Error(
           `${logNamePrefix}: ${mode}: ${unmatchedErrorMessage(
-            unmatchedLength,
+            cachedUnmatched,
             fixtureFilepath()
           )}`
         );
       } else if (isDryrunMode()) {
         console.warn( // eslint-disable-line no-console,prettier/prettier
-          `${logNamePrefix}: ${mode}: ${unmatchedLength} unmatched requests`
+          `${logNamePrefix}: ${mode}: ${
+            cachedUnmatched.length
+          } unmatched requests`
         );
       }
     }

--- a/src/createNockFixturesTestWrapper.js
+++ b/src/createNockFixturesTestWrapper.js
@@ -28,8 +28,10 @@ function createNockFixturesTestWrapper(options = {}) {
         'createNockFixturesTestWrapper: options.getTestPath must be a function'
       );
     },
-    unmatchedErrorMessage = unmatchedRequests =>
-      `unmatched requests not allowed (found ${unmatchedRequests}). Record fixtures and try again.`,
+    unmatchedErrorMessage = (unmatchedRequests, fixtureFilepath) =>
+      `unmatched requests not allowed (found ${
+        unmatchedRequests.length
+      }). Looking for fixtures at ${fixtureFilepath}. Record fixtures and try again.`,
   } = options;
 
   const fixtureDir = () =>
@@ -124,7 +126,10 @@ function createNockFixturesTestWrapper(options = {}) {
     if (unmatchedLength) {
       if (isLockdownMode()) {
         throw new Error(
-          `${logNamePrefix}: ${mode}: ${unmatchedErrorMessage(unmatchedLength)}`
+          `${logNamePrefix}: ${mode}: ${unmatchedErrorMessage(
+            unmatchedLength,
+            fixtureFilepath()
+          )}`
         );
       } else if (isDryrunMode()) {
         console.warn( // eslint-disable-line no-console,prettier/prettier

--- a/src/createNockFixturesTestWrapper.js
+++ b/src/createNockFixturesTestWrapper.js
@@ -28,7 +28,7 @@ function createNockFixturesTestWrapper(options = {}) {
         'createNockFixturesTestWrapper: options.getTestPath must be a function'
       );
     },
-    unmatchedErrorMessage = (unmatchedRequests, fixtureFilepath) =>
+    unmatchedErrorMessage = (unmatchedRequests, { fixtureFilepath }) =>
       `unmatched requests not allowed (found ${
         unmatchedRequests.length
       }). Looking for fixtures at ${fixtureFilepath}. Record fixtures and try again.`,
@@ -126,10 +126,9 @@ function createNockFixturesTestWrapper(options = {}) {
     if (cachedUnmatched.length) {
       if (isLockdownMode()) {
         throw new Error(
-          `${logNamePrefix}: ${mode}: ${unmatchedErrorMessage(
-            cachedUnmatched,
-            fixtureFilepath()
-          )}`
+          `${logNamePrefix}: ${mode}: ${unmatchedErrorMessage(cachedUnmatched, {
+            fixtureFilepath: fixtureFilepath(),
+          })}`
         );
       } else if (isDryrunMode()) {
         console.warn( // eslint-disable-line no-console,prettier/prettier

--- a/src/jest-nock-fixtures.js
+++ b/src/jest-nock-fixtures.js
@@ -55,10 +55,10 @@ module.exports = function createJestNockFixturesTestWrapper(options) {
     getFixtureFolderName = getJestNockFixtureFolderName,
     getTestPath = getJestGlobalTestPath,
     logNamePrefix = 'jest-nock-fixtures',
-    unmatchedErrorMessage = reqs =>
+    unmatchedErrorMessage = (reqs, fixtureFilepath) =>
       `unmatched requests not allowed (found ${
         reqs.length
-      }).\n\nRun with env variable \`JEST_NOCK_FIXTURES_MODE=record\` to update fixtures.`,
+      }). Looking for fixtures at ${fixtureFilepath}\n\nRun with env variable \`JEST_NOCK_FIXTURES_MODE=record\` to update fixtures.`,
     beforeAll = global.beforeAll,
     afterAll = global.afterAll,
   } = options;

--- a/src/jest-nock-fixtures.js
+++ b/src/jest-nock-fixtures.js
@@ -55,7 +55,7 @@ module.exports = function createJestNockFixturesTestWrapper(options) {
     getFixtureFolderName = getJestNockFixtureFolderName,
     getTestPath = getJestGlobalTestPath,
     logNamePrefix = 'jest-nock-fixtures',
-    unmatchedErrorMessage = (reqs, fixtureFilepath) =>
+    unmatchedErrorMessage = (reqs, { fixtureFilepath }) =>
       `unmatched requests not allowed (found ${
         reqs.length
       }). Looking for fixtures at ${fixtureFilepath}\n\nRun with env variable \`JEST_NOCK_FIXTURES_MODE=record\` to update fixtures.`,


### PR DESCRIPTION
- When nocks encounters a number of unmatched requests, the error function it calls now includes the path it expects to find the nock file at.
- Fixes a bug introduced in v1.0.2 where the first argument to `unmatchedErrorMessage` was the length of the unmatched request array instead of the array itself