### PR TITLE
fix dependency security warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.1 (2021-03-23) benjroy
+
+- run `npm update` and `npm audit fix` to clear security warning from dependencies
+
 ## 1.1.0 (2020-10-09) brian123zx
 
 - When nocks encounters a number of unmatched requests, the error function it calls now includes the path it expects to find the nock file at.

--- a/package-lock.json
+++ b/package-lock.json
@@ -607,9 +607,9 @@
       "dev": true
     },
     "acorn": {
-      "version": "6.1.1",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/acorn/-/acorn-6.1.1.tgz",
-      "integrity": "sha1-fSWuBbuK0fm2mRCOEJTs14hK3B8=",
+      "version": "6.4.2",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/acorn/-/acorn-6.4.2.tgz",
+      "integrity": "sha1-NYZv1xBSjpLeEM8GAWSY5H454eY=",
       "dev": true
     },
     "acorn-globals": {
@@ -1801,10 +1801,21 @@
       }
     },
     "eslint-utils": {
-      "version": "1.3.1",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/eslint-utils/-/eslint-utils-1.3.1.tgz",
-      "integrity": "sha1-moUbqJ7nxGA0b5fPiTnHKYgn5RI=",
-      "dev": true
+      "version": "1.4.3",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/eslint-utils/-/eslint-utils-1.4.3.tgz",
+      "integrity": "sha1-dP7HxU0Hdrb2fgJRBAtYBlZOmB8=",
+      "dev": true,
+      "requires": {
+        "eslint-visitor-keys": "^1.1.0"
+      },
+      "dependencies": {
+        "eslint-visitor-keys": {
+          "version": "1.3.0",
+          "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+          "integrity": "sha1-MOvR73wv3/AcOk8VEESvJfqwUj4=",
+          "dev": true
+        }
+      }
     },
     "eslint-visitor-keys": {
       "version": "1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,359 +1,371 @@
 {
   "name": "@nerdwallet/jest-nock-fixtures",
-  "requires": true,
+  "version": "1.1.0",
   "lockfileVersion": 1,
+  "requires": true,
   "dependencies": {
-    "@babel/core": {
-      "version": "7.4.5",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/@babel/core/-/core-7.4.5.tgz",
-      "integrity": "sha1-CB+X6P/KZam0sP3H4nTnA/AAwGo=",
+    "@babel/code-frame": {
+      "version": "7.12.13",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/@babel/code-frame/-/code-frame-7.12.13.tgz",
+      "integrity": "sha1-3PyCa+72XnXFDiHTg319lXmN1lg=",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.0.0",
-        "@babel/generator": "^7.4.4",
-        "@babel/helpers": "^7.4.4",
-        "@babel/parser": "^7.4.5",
-        "@babel/template": "^7.4.4",
-        "@babel/traverse": "^7.4.5",
-        "@babel/types": "^7.4.4",
-        "convert-source-map": "^1.1.0",
+        "@babel/highlight": "^7.12.13"
+      }
+    },
+    "@babel/compat-data": {
+      "version": "7.13.12",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/@babel/compat-data/-/compat-data-7.13.12.tgz",
+      "integrity": "sha1-qKXMrBnCAPndSWJMrG4Z174SNqE=",
+      "dev": true
+    },
+    "@babel/core": {
+      "version": "7.13.10",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/@babel/core/-/core-7.13.10.tgz",
+      "integrity": "sha1-B94FC72Bk/zYo8J5GMCJBhOpRVk=",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.12.13",
+        "@babel/generator": "^7.13.9",
+        "@babel/helper-compilation-targets": "^7.13.10",
+        "@babel/helper-module-transforms": "^7.13.0",
+        "@babel/helpers": "^7.13.10",
+        "@babel/parser": "^7.13.10",
+        "@babel/template": "^7.12.13",
+        "@babel/traverse": "^7.13.0",
+        "@babel/types": "^7.13.0",
+        "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
-        "json5": "^2.1.0",
-        "lodash": "^4.17.11",
-        "resolve": "^1.3.2",
-        "semver": "^5.4.1",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.1.2",
+        "lodash": "^4.17.19",
+        "semver": "^6.3.0",
         "source-map": "^0.5.0"
       },
       "dependencies": {
-        "@babel/code-frame": {
-          "version": "7.0.0",
-          "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/@babel/code-frame/-/code-frame-7.0.0.tgz",
-          "integrity": "sha1-BuKrGb21NThVWaq7W6WXKUgoAPg=",
-          "dev": true,
-          "requires": {
-            "@babel/highlight": "^7.0.0"
-          }
-        },
-        "@babel/generator": {
-          "version": "7.4.4",
-          "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/@babel/generator/-/generator-7.4.4.tgz",
-          "integrity": "sha1-F0ohXrhD/DksftyqvqqHPebo8EE=",
-          "dev": true,
-          "requires": {
-            "@babel/types": "^7.4.4",
-            "jsesc": "^2.5.1",
-            "lodash": "^4.17.11",
-            "source-map": "^0.5.0",
-            "trim-right": "^1.0.1"
-          }
-        },
-        "@babel/helper-function-name": {
-          "version": "7.1.0",
-          "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
-          "integrity": "sha1-oM6wFoX3M1XUNgwSR/WCv6/I/1M=",
-          "dev": true,
-          "requires": {
-            "@babel/helper-get-function-arity": "^7.0.0",
-            "@babel/template": "^7.1.0",
-            "@babel/types": "^7.0.0"
-          }
-        },
-        "@babel/helper-get-function-arity": {
-          "version": "7.0.0",
-          "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
-          "integrity": "sha1-g1ctQyDipGVyY3NBE8QoaLZOScM=",
-          "dev": true,
-          "requires": {
-            "@babel/types": "^7.0.0"
-          }
-        },
-        "@babel/helper-split-export-declaration": {
-          "version": "7.4.4",
-          "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
-          "integrity": "sha1-/5SJSjQL549T8GrwOLIFxJ2ZNnc=",
-          "dev": true,
-          "requires": {
-            "@babel/types": "^7.4.4"
-          }
-        },
-        "@babel/highlight": {
-          "version": "7.0.0",
-          "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/@babel/highlight/-/highlight-7.0.0.tgz",
-          "integrity": "sha1-9xDDjI1Fjm3ZogGvtjf8t4HOmeQ=",
-          "dev": true,
-          "requires": {
-            "chalk": "^2.0.0",
-            "esutils": "^2.0.2",
-            "js-tokens": "^4.0.0"
-          }
-        },
-        "@babel/template": {
-          "version": "7.4.4",
-          "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/@babel/template/-/template-7.4.4.tgz",
-          "integrity": "sha1-9LiNEiVomgj1vDoXSDVFvp5O0jc=",
-          "dev": true,
-          "requires": {
-            "@babel/code-frame": "^7.0.0",
-            "@babel/parser": "^7.4.4",
-            "@babel/types": "^7.4.4"
-          }
-        },
-        "@babel/traverse": {
-          "version": "7.4.5",
-          "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/@babel/traverse/-/traverse-7.4.5.tgz",
-          "integrity": "sha1-TpLRco/S8Yl9r90yHvv/khVsMhY=",
-          "dev": true,
-          "requires": {
-            "@babel/code-frame": "^7.0.0",
-            "@babel/generator": "^7.4.4",
-            "@babel/helper-function-name": "^7.1.0",
-            "@babel/helper-split-export-declaration": "^7.4.4",
-            "@babel/parser": "^7.4.5",
-            "@babel/types": "^7.4.4",
-            "debug": "^4.1.0",
-            "globals": "^11.1.0",
-            "lodash": "^4.17.11"
-          }
-        },
-        "@babel/types": {
-          "version": "7.4.4",
-          "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/@babel/types/-/types-7.4.4.tgz",
-          "integrity": "sha1-jbnppim7fCk3AAm0t3ntk/5X1fA=",
-          "dev": true,
-          "requires": {
-            "esutils": "^2.0.2",
-            "lodash": "^4.17.11",
-            "to-fast-properties": "^2.0.0"
-          }
-        },
         "debug": {
-          "version": "4.1.1",
-          "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
+          "version": "4.3.1",
+          "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha1-8NIpxQXgxtjEmsVT0bE9wYP2su4=",
           "dev": true,
           "requires": {
-            "ms": "^2.1.1"
+            "ms": "2.1.2"
           }
         },
-        "js-tokens": {
-          "version": "4.0.0",
-          "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/js-tokens/-/js-tokens-4.0.0.tgz",
-          "integrity": "sha1-GSA/tZmR35jjoocFDUZHzerzJJk=",
+        "json5": {
+          "version": "2.2.0",
+          "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/json5/-/json5-2.2.0.tgz",
+          "integrity": "sha1-Lf7+cgxrpSXZ69kJlQ8FFTFsiaM=",
+          "dev": true,
+          "requires": {
+            "minimist": "^1.2.5"
+          }
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha1-7gpkyK9ejO6mdoexM3YeG+y9HT0=",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
           "dev": true
         }
+      }
+    },
+    "@babel/generator": {
+      "version": "7.13.9",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/@babel/generator/-/generator-7.13.9.tgz",
+      "integrity": "sha1-Onqpb577jivkLTjYDizrTGTY3jk=",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.13.0",
+        "jsesc": "^2.5.1",
+        "source-map": "^0.5.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        }
+      }
+    },
+    "@babel/helper-compilation-targets": {
+      "version": "7.13.10",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/@babel/helper-compilation-targets/-/helper-compilation-targets-7.13.10.tgz",
+      "integrity": "sha1-ExChZ4y4QnwHp1N1DaT4zkQr3Qw=",
+      "dev": true,
+      "requires": {
+        "@babel/compat-data": "^7.13.8",
+        "@babel/helper-validator-option": "^7.12.17",
+        "browserslist": "^4.14.5",
+        "semver": "^6.3.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha1-7gpkyK9ejO6mdoexM3YeG+y9HT0=",
+          "dev": true
+        }
+      }
+    },
+    "@babel/helper-function-name": {
+      "version": "7.12.13",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/@babel/helper-function-name/-/helper-function-name-7.12.13.tgz",
+      "integrity": "sha1-k61lbbPDwiMlWf17LD29y+DrN3o=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-get-function-arity": "^7.12.13",
+        "@babel/template": "^7.12.13",
+        "@babel/types": "^7.12.13"
+      }
+    },
+    "@babel/helper-get-function-arity": {
+      "version": "7.12.13",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/@babel/helper-get-function-arity/-/helper-get-function-arity-7.12.13.tgz",
+      "integrity": "sha1-vGNFHUA6OzCCuX4diz/lvUCR5YM=",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.12.13"
+      }
+    },
+    "@babel/helper-member-expression-to-functions": {
+      "version": "7.13.12",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.13.12.tgz",
+      "integrity": "sha1-3+No8m1CagcpnY1lE4IXaCFubXI=",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.13.12"
+      }
+    },
+    "@babel/helper-module-imports": {
+      "version": "7.13.12",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/@babel/helper-module-imports/-/helper-module-imports-7.13.12.tgz",
+      "integrity": "sha1-xqNppvNiHLJdoBQHhoTakZa2GXc=",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.13.12"
+      }
+    },
+    "@babel/helper-module-transforms": {
+      "version": "7.13.12",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/@babel/helper-module-transforms/-/helper-module-transforms-7.13.12.tgz",
+      "integrity": "sha1-YA5YNQSQgo2CKCYxoUIiaOmCupY=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-imports": "^7.13.12",
+        "@babel/helper-replace-supers": "^7.13.12",
+        "@babel/helper-simple-access": "^7.13.12",
+        "@babel/helper-split-export-declaration": "^7.12.13",
+        "@babel/helper-validator-identifier": "^7.12.11",
+        "@babel/template": "^7.12.13",
+        "@babel/traverse": "^7.13.0",
+        "@babel/types": "^7.13.12"
+      }
+    },
+    "@babel/helper-optimise-call-expression": {
+      "version": "7.12.13",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.12.13.tgz",
+      "integrity": "sha1-XALRcbTIYVsecWP4iMHIHDCiquo=",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.12.13"
       }
     },
     "@babel/helper-plugin-utils": {
-      "version": "7.0.0",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0.tgz",
-      "integrity": "sha1-u7P77phmHFaQNCN8wDlnupm08lA=",
+      "version": "7.13.0",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/@babel/helper-plugin-utils/-/helper-plugin-utils-7.13.0.tgz",
+      "integrity": "sha1-gGUmzhJa7QM3O8QWqCgyHjpqM68=",
+      "dev": true
+    },
+    "@babel/helper-replace-supers": {
+      "version": "7.13.12",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/@babel/helper-replace-supers/-/helper-replace-supers-7.13.12.tgz",
+      "integrity": "sha1-ZEL0wa2RJQJIGlZKc4beDHf/OAQ=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-member-expression-to-functions": "^7.13.12",
+        "@babel/helper-optimise-call-expression": "^7.12.13",
+        "@babel/traverse": "^7.13.0",
+        "@babel/types": "^7.13.12"
+      }
+    },
+    "@babel/helper-simple-access": {
+      "version": "7.13.12",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/@babel/helper-simple-access/-/helper-simple-access-7.13.12.tgz",
+      "integrity": "sha1-3WxTivthgZ0gWgEsMXkqOcel6vY=",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.13.12"
+      }
+    },
+    "@babel/helper-split-export-declaration": {
+      "version": "7.12.13",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.13.tgz",
+      "integrity": "sha1-6UML4AuvPoiw4T5vnU6vITY3KwU=",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.12.13"
+      }
+    },
+    "@babel/helper-validator-identifier": {
+      "version": "7.12.11",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
+      "integrity": "sha1-yaHwIZF9y1zPDU5FPjmQIpgfye0=",
+      "dev": true
+    },
+    "@babel/helper-validator-option": {
+      "version": "7.12.17",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/@babel/helper-validator-option/-/helper-validator-option-7.12.17.tgz",
+      "integrity": "sha1-0fvwEuGnm37rv9xtJwuq+NnrmDE=",
       "dev": true
     },
     "@babel/helpers": {
-      "version": "7.4.4",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/@babel/helpers/-/helpers-7.4.4.tgz",
-      "integrity": "sha1-hosO9Zwd1OeHRFYtXOG1nIny8qU=",
+      "version": "7.13.10",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/@babel/helpers/-/helpers-7.13.10.tgz",
+      "integrity": "sha1-/Y4rp0iFM83qxFzBWOnryl48ffg=",
       "dev": true,
       "requires": {
-        "@babel/template": "^7.4.4",
-        "@babel/traverse": "^7.4.4",
-        "@babel/types": "^7.4.4"
-      },
-      "dependencies": {
-        "@babel/code-frame": {
-          "version": "7.0.0",
-          "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/@babel/code-frame/-/code-frame-7.0.0.tgz",
-          "integrity": "sha1-BuKrGb21NThVWaq7W6WXKUgoAPg=",
-          "dev": true,
-          "requires": {
-            "@babel/highlight": "^7.0.0"
-          }
-        },
-        "@babel/generator": {
-          "version": "7.4.4",
-          "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/@babel/generator/-/generator-7.4.4.tgz",
-          "integrity": "sha1-F0ohXrhD/DksftyqvqqHPebo8EE=",
-          "dev": true,
-          "requires": {
-            "@babel/types": "^7.4.4",
-            "jsesc": "^2.5.1",
-            "lodash": "^4.17.11",
-            "source-map": "^0.5.0",
-            "trim-right": "^1.0.1"
-          }
-        },
-        "@babel/helper-function-name": {
-          "version": "7.1.0",
-          "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
-          "integrity": "sha1-oM6wFoX3M1XUNgwSR/WCv6/I/1M=",
-          "dev": true,
-          "requires": {
-            "@babel/helper-get-function-arity": "^7.0.0",
-            "@babel/template": "^7.1.0",
-            "@babel/types": "^7.0.0"
-          }
-        },
-        "@babel/helper-get-function-arity": {
-          "version": "7.0.0",
-          "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
-          "integrity": "sha1-g1ctQyDipGVyY3NBE8QoaLZOScM=",
-          "dev": true,
-          "requires": {
-            "@babel/types": "^7.0.0"
-          }
-        },
-        "@babel/helper-split-export-declaration": {
-          "version": "7.4.4",
-          "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
-          "integrity": "sha1-/5SJSjQL549T8GrwOLIFxJ2ZNnc=",
-          "dev": true,
-          "requires": {
-            "@babel/types": "^7.4.4"
-          }
-        },
-        "@babel/highlight": {
-          "version": "7.0.0",
-          "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/@babel/highlight/-/highlight-7.0.0.tgz",
-          "integrity": "sha1-9xDDjI1Fjm3ZogGvtjf8t4HOmeQ=",
-          "dev": true,
-          "requires": {
-            "chalk": "^2.0.0",
-            "esutils": "^2.0.2",
-            "js-tokens": "^4.0.0"
-          }
-        },
-        "@babel/template": {
-          "version": "7.4.4",
-          "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/@babel/template/-/template-7.4.4.tgz",
-          "integrity": "sha1-9LiNEiVomgj1vDoXSDVFvp5O0jc=",
-          "dev": true,
-          "requires": {
-            "@babel/code-frame": "^7.0.0",
-            "@babel/parser": "^7.4.4",
-            "@babel/types": "^7.4.4"
-          }
-        },
-        "@babel/traverse": {
-          "version": "7.4.5",
-          "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/@babel/traverse/-/traverse-7.4.5.tgz",
-          "integrity": "sha1-TpLRco/S8Yl9r90yHvv/khVsMhY=",
-          "dev": true,
-          "requires": {
-            "@babel/code-frame": "^7.0.0",
-            "@babel/generator": "^7.4.4",
-            "@babel/helper-function-name": "^7.1.0",
-            "@babel/helper-split-export-declaration": "^7.4.4",
-            "@babel/parser": "^7.4.5",
-            "@babel/types": "^7.4.4",
-            "debug": "^4.1.0",
-            "globals": "^11.1.0",
-            "lodash": "^4.17.11"
-          }
-        },
-        "@babel/types": {
-          "version": "7.4.4",
-          "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/@babel/types/-/types-7.4.4.tgz",
-          "integrity": "sha1-jbnppim7fCk3AAm0t3ntk/5X1fA=",
-          "dev": true,
-          "requires": {
-            "esutils": "^2.0.2",
-            "lodash": "^4.17.11",
-            "to-fast-properties": "^2.0.0"
-          }
-        },
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "js-tokens": {
-          "version": "4.0.0",
-          "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/js-tokens/-/js-tokens-4.0.0.tgz",
-          "integrity": "sha1-GSA/tZmR35jjoocFDUZHzerzJJk=",
-          "dev": true
-        }
+        "@babel/template": "^7.12.13",
+        "@babel/traverse": "^7.13.0",
+        "@babel/types": "^7.13.0"
+      }
+    },
+    "@babel/highlight": {
+      "version": "7.13.10",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/@babel/highlight/-/highlight-7.13.10.tgz",
+      "integrity": "sha1-qLKmYUj1sn1maxXYF3Q0enMdUtE=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-validator-identifier": "^7.12.11",
+        "chalk": "^2.0.0",
+        "js-tokens": "^4.0.0"
       }
     },
     "@babel/parser": {
-      "version": "7.4.5",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/@babel/parser/-/parser-7.4.5.tgz",
-      "integrity": "sha1-BK+NXVorBEoqG/+sweXmZzVE6HI=",
+      "version": "7.13.12",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/@babel/parser/-/parser-7.13.12.tgz",
+      "integrity": "sha1-ujIAWUIHdDlNOwwCM7pA5CULgdE=",
       "dev": true
     },
     "@babel/plugin-syntax-object-rest-spread": {
-      "version": "7.2.0",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.2.0.tgz",
-      "integrity": "sha1-O3o+czUQxX6CC5FCpleayLDfrS4=",
+      "version": "7.8.3",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz",
+      "integrity": "sha1-YOIl7cvZimQDMqLnLdPmbxr1WHE=",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0"
+        "@babel/helper-plugin-utils": "^7.8.0"
+      }
+    },
+    "@babel/template": {
+      "version": "7.12.13",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/@babel/template/-/template-7.12.13.tgz",
+      "integrity": "sha1-UwJlvooliduzdSOETFvLVZR/syc=",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.12.13",
+        "@babel/parser": "^7.12.13",
+        "@babel/types": "^7.12.13"
+      }
+    },
+    "@babel/traverse": {
+      "version": "7.13.0",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/@babel/traverse/-/traverse-7.13.0.tgz",
+      "integrity": "sha1-bZV1JHX4bufe0GU23jCaZfyJZsw=",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.12.13",
+        "@babel/generator": "^7.13.0",
+        "@babel/helper-function-name": "^7.12.13",
+        "@babel/helper-split-export-declaration": "^7.12.13",
+        "@babel/parser": "^7.13.0",
+        "@babel/types": "^7.13.0",
+        "debug": "^4.1.0",
+        "globals": "^11.1.0",
+        "lodash": "^4.17.19"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.1",
+          "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha1-8NIpxQXgxtjEmsVT0bE9wYP2su4=",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        }
+      }
+    },
+    "@babel/types": {
+      "version": "7.13.12",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/@babel/types/-/types-7.13.12.tgz",
+      "integrity": "sha1-7b+ZII70iFKs3/HIpoGh5K3lgM0=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-validator-identifier": "^7.12.11",
+        "lodash": "^4.17.19",
+        "to-fast-properties": "^2.0.0"
       }
     },
     "@cnakazawa/watch": {
-      "version": "1.0.3",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/@cnakazawa/watch/-/watch-1.0.3.tgz",
-      "integrity": "sha1-CZE56ux+vweifBeGo/9k85Rk0u8=",
+      "version": "1.0.4",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/@cnakazawa/watch/-/watch-1.0.4.tgz",
+      "integrity": "sha1-+GSuhQBND8q29QvpFBxNo2jRZWo=",
       "dev": true,
       "requires": {
         "exec-sh": "^0.3.2",
         "minimist": "^1.2.0"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-          "dev": true
-        }
       }
     },
     "@jest/console": {
-      "version": "24.7.1",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/@jest/console/-/console-24.7.1.tgz",
-      "integrity": "sha1-MqnkJTWpeu3+A35yW9Z+lUtFlUU=",
+      "version": "24.9.0",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/@jest/console/-/console-24.9.0.tgz",
+      "integrity": "sha1-ebG8Bvt0qM+wHL3t+UVYSxuXB/A=",
       "dev": true,
       "requires": {
-        "@jest/source-map": "^24.3.0",
+        "@jest/source-map": "^24.9.0",
         "chalk": "^2.0.1",
         "slash": "^2.0.0"
       }
     },
     "@jest/core": {
-      "version": "24.8.0",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/@jest/core/-/core-24.8.0.tgz",
-      "integrity": "sha1-+73NQqQdDTnN28n1IMi6sMM+7Vs=",
+      "version": "24.9.0",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/@jest/core/-/core-24.9.0.tgz",
+      "integrity": "sha1-LOzNC5MYH5xIUOdPKprUPTUTacQ=",
       "dev": true,
       "requires": {
         "@jest/console": "^24.7.1",
-        "@jest/reporters": "^24.8.0",
-        "@jest/test-result": "^24.8.0",
-        "@jest/transform": "^24.8.0",
-        "@jest/types": "^24.8.0",
+        "@jest/reporters": "^24.9.0",
+        "@jest/test-result": "^24.9.0",
+        "@jest/transform": "^24.9.0",
+        "@jest/types": "^24.9.0",
         "ansi-escapes": "^3.0.0",
         "chalk": "^2.0.1",
         "exit": "^0.1.2",
         "graceful-fs": "^4.1.15",
-        "jest-changed-files": "^24.8.0",
-        "jest-config": "^24.8.0",
-        "jest-haste-map": "^24.8.0",
-        "jest-message-util": "^24.8.0",
+        "jest-changed-files": "^24.9.0",
+        "jest-config": "^24.9.0",
+        "jest-haste-map": "^24.9.0",
+        "jest-message-util": "^24.9.0",
         "jest-regex-util": "^24.3.0",
-        "jest-resolve-dependencies": "^24.8.0",
-        "jest-runner": "^24.8.0",
-        "jest-runtime": "^24.8.0",
-        "jest-snapshot": "^24.8.0",
-        "jest-util": "^24.8.0",
-        "jest-validate": "^24.8.0",
-        "jest-watcher": "^24.8.0",
+        "jest-resolve": "^24.9.0",
+        "jest-resolve-dependencies": "^24.9.0",
+        "jest-runner": "^24.9.0",
+        "jest-runtime": "^24.9.0",
+        "jest-snapshot": "^24.9.0",
+        "jest-util": "^24.9.0",
+        "jest-validate": "^24.9.0",
+        "jest-watcher": "^24.9.0",
         "micromatch": "^3.1.10",
         "p-each-series": "^1.0.0",
-        "pirates": "^4.0.1",
         "realpath-native": "^1.1.0",
         "rimraf": "^2.5.4",
+        "slash": "^2.0.0",
         "strip-ansi": "^5.0.0"
       },
       "dependencies": {
@@ -375,38 +387,38 @@
       }
     },
     "@jest/environment": {
-      "version": "24.8.0",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/@jest/environment/-/environment-24.8.0.tgz",
-      "integrity": "sha1-A0ImE4PHdr3WUhaPaAZe8USvDqw=",
+      "version": "24.9.0",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/@jest/environment/-/environment-24.9.0.tgz",
+      "integrity": "sha1-IeOvotZcBYbL1svv4gi6+t5Eqxg=",
       "dev": true,
       "requires": {
-        "@jest/fake-timers": "^24.8.0",
-        "@jest/transform": "^24.8.0",
-        "@jest/types": "^24.8.0",
-        "jest-mock": "^24.8.0"
+        "@jest/fake-timers": "^24.9.0",
+        "@jest/transform": "^24.9.0",
+        "@jest/types": "^24.9.0",
+        "jest-mock": "^24.9.0"
       }
     },
     "@jest/fake-timers": {
-      "version": "24.8.0",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/@jest/fake-timers/-/fake-timers-24.8.0.tgz",
-      "integrity": "sha1-LluApPePKEvLS9VxS44Q3Tao09E=",
+      "version": "24.9.0",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/@jest/fake-timers/-/fake-timers-24.9.0.tgz",
+      "integrity": "sha1-uj5r8O7NCaY2BJiWQ00wZjZUDJM=",
       "dev": true,
       "requires": {
-        "@jest/types": "^24.8.0",
-        "jest-message-util": "^24.8.0",
-        "jest-mock": "^24.8.0"
+        "@jest/types": "^24.9.0",
+        "jest-message-util": "^24.9.0",
+        "jest-mock": "^24.9.0"
       }
     },
     "@jest/reporters": {
-      "version": "24.8.0",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/@jest/reporters/-/reporters-24.8.0.tgz",
-      "integrity": "sha1-B1FpzQKb3exUuPLA/Eif0LngVyk=",
+      "version": "24.9.0",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/@jest/reporters/-/reporters-24.9.0.tgz",
+      "integrity": "sha1-hmYO/44rlmHQQqjpigKLjWMaW0M=",
       "dev": true,
       "requires": {
-        "@jest/environment": "^24.8.0",
-        "@jest/test-result": "^24.8.0",
-        "@jest/transform": "^24.8.0",
-        "@jest/types": "^24.8.0",
+        "@jest/environment": "^24.9.0",
+        "@jest/test-result": "^24.9.0",
+        "@jest/transform": "^24.9.0",
+        "@jest/types": "^24.9.0",
         "chalk": "^2.0.1",
         "exit": "^0.1.2",
         "glob": "^7.1.2",
@@ -414,114 +426,91 @@
         "istanbul-lib-instrument": "^3.0.1",
         "istanbul-lib-report": "^2.0.4",
         "istanbul-lib-source-maps": "^3.0.1",
-        "istanbul-reports": "^2.1.1",
-        "jest-haste-map": "^24.8.0",
-        "jest-resolve": "^24.8.0",
-        "jest-runtime": "^24.8.0",
-        "jest-util": "^24.8.0",
+        "istanbul-reports": "^2.2.6",
+        "jest-haste-map": "^24.9.0",
+        "jest-resolve": "^24.9.0",
+        "jest-runtime": "^24.9.0",
+        "jest-util": "^24.9.0",
         "jest-worker": "^24.6.0",
-        "node-notifier": "^5.2.1",
+        "node-notifier": "^5.4.2",
         "slash": "^2.0.0",
         "source-map": "^0.6.0",
         "string-length": "^2.0.0"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
-          "dev": true
-        }
       }
     },
     "@jest/source-map": {
-      "version": "24.3.0",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/@jest/source-map/-/source-map-24.3.0.tgz",
-      "integrity": "sha1-Vjvjqk0iTK9l/3ftyVzRyk2mfyg=",
+      "version": "24.9.0",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/@jest/source-map/-/source-map-24.9.0.tgz",
+      "integrity": "sha1-DiY6lEML5LQdpoPMwea//ioZFxQ=",
       "dev": true,
       "requires": {
         "callsites": "^3.0.0",
         "graceful-fs": "^4.1.15",
         "source-map": "^0.6.0"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
-          "dev": true
-        }
       }
     },
     "@jest/test-result": {
-      "version": "24.8.0",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/@jest/test-result/-/test-result-24.8.0.tgz",
-      "integrity": "sha1-dnXQqvnSSEyqZeBI2bRn0WD46dM=",
+      "version": "24.9.0",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/@jest/test-result/-/test-result-24.9.0.tgz",
+      "integrity": "sha1-EXluiqnb+I6gJXV7MVJZWtBroMo=",
       "dev": true,
       "requires": {
-        "@jest/console": "^24.7.1",
-        "@jest/types": "^24.8.0",
+        "@jest/console": "^24.9.0",
+        "@jest/types": "^24.9.0",
         "@types/istanbul-lib-coverage": "^2.0.0"
       }
     },
     "@jest/test-sequencer": {
-      "version": "24.8.0",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/@jest/test-sequencer/-/test-sequencer-24.8.0.tgz",
-      "integrity": "sha1-L5k7z271605l6CM6laMyAkjPmUs=",
+      "version": "24.9.0",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/@jest/test-sequencer/-/test-sequencer-24.9.0.tgz",
+      "integrity": "sha1-+PM081tiWk8vNV8v5+YDba0uazE=",
       "dev": true,
       "requires": {
-        "@jest/test-result": "^24.8.0",
-        "jest-haste-map": "^24.8.0",
-        "jest-runner": "^24.8.0",
-        "jest-runtime": "^24.8.0"
+        "@jest/test-result": "^24.9.0",
+        "jest-haste-map": "^24.9.0",
+        "jest-runner": "^24.9.0",
+        "jest-runtime": "^24.9.0"
       }
     },
     "@jest/transform": {
-      "version": "24.8.0",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/@jest/transform/-/transform-24.8.0.tgz",
-      "integrity": "sha1-Yo+5nc5PnSVMb9k0Hj7qJi4G/vU=",
+      "version": "24.9.0",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/@jest/transform/-/transform-24.9.0.tgz",
+      "integrity": "sha1-SuJ2iyllU/rasJ6ewRlUPJCxbFY=",
       "dev": true,
       "requires": {
         "@babel/core": "^7.1.0",
-        "@jest/types": "^24.8.0",
+        "@jest/types": "^24.9.0",
         "babel-plugin-istanbul": "^5.1.0",
         "chalk": "^2.0.1",
         "convert-source-map": "^1.4.0",
         "fast-json-stable-stringify": "^2.0.0",
         "graceful-fs": "^4.1.15",
-        "jest-haste-map": "^24.8.0",
-        "jest-regex-util": "^24.3.0",
-        "jest-util": "^24.8.0",
+        "jest-haste-map": "^24.9.0",
+        "jest-regex-util": "^24.9.0",
+        "jest-util": "^24.9.0",
         "micromatch": "^3.1.10",
+        "pirates": "^4.0.1",
         "realpath-native": "^1.1.0",
         "slash": "^2.0.0",
         "source-map": "^0.6.1",
         "write-file-atomic": "2.4.1"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
-          "dev": true
-        }
       }
     },
     "@jest/types": {
-      "version": "24.8.0",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/@jest/types/-/types-24.8.0.tgz",
-      "integrity": "sha1-8x4llIxY8KvYyEWuJvzqFJHep60=",
+      "version": "24.9.0",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/@jest/types/-/types-24.9.0.tgz",
+      "integrity": "sha1-Y8smy3UA0Gnlo4lEGnxqtekJ/Fk=",
       "dev": true,
       "requires": {
         "@types/istanbul-lib-coverage": "^2.0.0",
         "@types/istanbul-reports": "^1.1.1",
-        "@types/yargs": "^12.0.9"
+        "@types/yargs": "^13.0.0"
       }
     },
     "@types/babel__core": {
-      "version": "7.1.2",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/@types/babel__core/-/babel__core-7.1.2.tgz",
-      "integrity": "sha1-YIx09VkoAz/OGLmbITwWvks9EU8=",
+      "version": "7.1.14",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/@types/babel__core/-/babel__core-7.1.14.tgz",
+      "integrity": "sha1-+q7vxBhexxw4n0UB7l7ISxcMxAI=",
       "dev": true,
       "requires": {
         "@babel/parser": "^7.1.0",
@@ -529,112 +518,66 @@
         "@types/babel__generator": "*",
         "@types/babel__template": "*",
         "@types/babel__traverse": "*"
-      },
-      "dependencies": {
-        "@babel/types": {
-          "version": "7.4.4",
-          "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/@babel/types/-/types-7.4.4.tgz",
-          "integrity": "sha1-jbnppim7fCk3AAm0t3ntk/5X1fA=",
-          "dev": true,
-          "requires": {
-            "esutils": "^2.0.2",
-            "lodash": "^4.17.11",
-            "to-fast-properties": "^2.0.0"
-          }
-        }
       }
     },
     "@types/babel__generator": {
-      "version": "7.0.2",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/@types/babel__generator/-/babel__generator-7.0.2.tgz",
-      "integrity": "sha1-0hEqayH61gDXZ0J0KTyF3ODLR/w=",
+      "version": "7.6.2",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/@types/babel__generator/-/babel__generator-7.6.2.tgz",
+      "integrity": "sha1-89cReOGHhY98ReMDgPjxt0FaEtg=",
       "dev": true,
       "requires": {
         "@babel/types": "^7.0.0"
-      },
-      "dependencies": {
-        "@babel/types": {
-          "version": "7.4.4",
-          "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/@babel/types/-/types-7.4.4.tgz",
-          "integrity": "sha1-jbnppim7fCk3AAm0t3ntk/5X1fA=",
-          "dev": true,
-          "requires": {
-            "esutils": "^2.0.2",
-            "lodash": "^4.17.11",
-            "to-fast-properties": "^2.0.0"
-          }
-        }
       }
     },
     "@types/babel__template": {
-      "version": "7.0.2",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/@types/babel__template/-/babel__template-7.0.2.tgz",
-      "integrity": "sha1-T/Y9a1Lt2sHee5daUiPtMuzqkwc=",
+      "version": "7.4.0",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/@types/babel__template/-/babel__template-7.4.0.tgz",
+      "integrity": "sha1-DIiN1ws+6e67bk8gDoCdoAdiYr4=",
       "dev": true,
       "requires": {
         "@babel/parser": "^7.1.0",
         "@babel/types": "^7.0.0"
-      },
-      "dependencies": {
-        "@babel/types": {
-          "version": "7.4.4",
-          "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/@babel/types/-/types-7.4.4.tgz",
-          "integrity": "sha1-jbnppim7fCk3AAm0t3ntk/5X1fA=",
-          "dev": true,
-          "requires": {
-            "esutils": "^2.0.2",
-            "lodash": "^4.17.11",
-            "to-fast-properties": "^2.0.0"
-          }
-        }
       }
     },
     "@types/babel__traverse": {
-      "version": "7.0.7",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/@types/babel__traverse/-/babel__traverse-7.0.7.tgz",
-      "integrity": "sha1-JJbp/1YZbMFCnHIDTgfqthIbbz8=",
+      "version": "7.11.1",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/@types/babel__traverse/-/babel__traverse-7.11.1.tgz",
+      "integrity": "sha1-ZU9sT2dWjiTCOzZ+lHCYxiBvpjk=",
       "dev": true,
       "requires": {
         "@babel/types": "^7.3.0"
-      },
-      "dependencies": {
-        "@babel/types": {
-          "version": "7.4.4",
-          "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/@babel/types/-/types-7.4.4.tgz",
-          "integrity": "sha1-jbnppim7fCk3AAm0t3ntk/5X1fA=",
-          "dev": true,
-          "requires": {
-            "esutils": "^2.0.2",
-            "lodash": "^4.17.11",
-            "to-fast-properties": "^2.0.0"
-          }
-        }
       }
     },
     "@types/istanbul-lib-coverage": {
-      "version": "2.0.1",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz",
-      "integrity": "sha1-QplbRG25pIoRoH7Ag0mahg6ROP8=",
+      "version": "2.0.3",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz",
+      "integrity": "sha1-S6jdtyAiH0MuRDvV+RF/0iz9R2I=",
       "dev": true
     },
     "@types/istanbul-lib-report": {
-      "version": "1.1.1",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/@types/istanbul-lib-report/-/istanbul-lib-report-1.1.1.tgz",
-      "integrity": "sha1-5Ucef6M8YTWN04QmGJwDelhDO4w=",
+      "version": "3.0.0",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz",
+      "integrity": "sha1-wUwk8Y6oGQwRjudWK3/5mjZVJoY=",
       "dev": true,
       "requires": {
         "@types/istanbul-lib-coverage": "*"
       }
     },
     "@types/istanbul-reports": {
-      "version": "1.1.1",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/@types/istanbul-reports/-/istanbul-reports-1.1.1.tgz",
-      "integrity": "sha1-eoy/akBvNsit2HFiWyeOrwsNJVo=",
+      "version": "1.1.2",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/@types/istanbul-reports/-/istanbul-reports-1.1.2.tgz",
+      "integrity": "sha1-6HXMaJ5HvOVJ7IHz315vbxHPrrI=",
       "dev": true,
       "requires": {
         "@types/istanbul-lib-coverage": "*",
         "@types/istanbul-lib-report": "*"
       }
+    },
+    "@types/json5": {
+      "version": "0.0.29",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/@types/json5/-/json5-0.0.29.tgz",
+      "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
+      "dev": true
     },
     "@types/stack-utils": {
       "version": "1.0.1",
@@ -643,15 +586,24 @@
       "dev": true
     },
     "@types/yargs": {
-      "version": "12.0.12",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/@types/yargs/-/yargs-12.0.12.tgz",
-      "integrity": "sha1-Rd0dBjjoyPFT6H0paQdlkpaHORY=",
+      "version": "13.0.11",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/@types/yargs/-/yargs-13.0.11.tgz",
+      "integrity": "sha1-3vLwyT5L3yxh1+NImbF+NL4o07E=",
+      "dev": true,
+      "requires": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "@types/yargs-parser": {
+      "version": "20.2.0",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/@types/yargs-parser/-/yargs-parser-20.2.0.tgz",
+      "integrity": "sha1-3T5mmboyN/A0jNCF5GmHgCBIQvk=",
       "dev": true
     },
     "abab": {
-      "version": "2.0.0",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/abab/-/abab-2.0.0.tgz",
-      "integrity": "sha1-q6CrTF7uLUx500h9hUUPsjduuw8=",
+      "version": "2.0.5",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/abab/-/abab-2.0.5.tgz",
+      "integrity": "sha1-wLZ4+zLWD8EhnHhNaoJv44Wut5o=",
       "dev": true
     },
     "acorn": {
@@ -661,9 +613,9 @@
       "dev": true
     },
     "acorn-globals": {
-      "version": "4.3.2",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/acorn-globals/-/acorn-globals-4.3.2.tgz",
-      "integrity": "sha1-TiwjE6WX/ViXIDlfY1S0HNXsgAY=",
+      "version": "4.3.4",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/acorn-globals/-/acorn-globals-4.3.4.tgz",
+      "integrity": "sha1-n6GSat3BHJcwjE5m163Q1Awycuc=",
       "dev": true,
       "requires": {
         "acorn": "^6.0.1",
@@ -677,9 +629,9 @@
       "dev": true
     },
     "acorn-walk": {
-      "version": "6.1.1",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/acorn-walk/-/acorn-walk-6.1.1.tgz",
-      "integrity": "sha1-02O2b1+sXwGP+cOh57b44xDMORM=",
+      "version": "6.2.0",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/acorn-walk/-/acorn-walk-6.2.0.tgz",
+      "integrity": "sha1-Ejy487hMIXHx9/slJhWxx4prGow=",
       "dev": true
     },
     "ajv": {
@@ -723,17 +675,6 @@
       "requires": {
         "micromatch": "^3.1.4",
         "normalize-path": "^2.1.1"
-      },
-      "dependencies": {
-        "normalize-path": {
-          "version": "2.1.1",
-          "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/normalize-path/-/normalize-path-2.1.1.tgz",
-          "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-          "dev": true,
-          "requires": {
-            "remove-trailing-separator": "^1.0.1"
-          }
-        }
       }
     },
     "argparse": {
@@ -770,13 +711,16 @@
       "dev": true
     },
     "array-includes": {
-      "version": "3.0.3",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/array-includes/-/array-includes-3.0.3.tgz",
-      "integrity": "sha1-GEtI9i2S10UrsxsyMWXH+L0CJm0=",
+      "version": "3.1.3",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/array-includes/-/array-includes-3.1.3.tgz",
+      "integrity": "sha1-x/YZs4KtKvr1Mmzd/cCvxhr3aQo=",
       "dev": true,
       "requires": {
-        "define-properties": "^1.1.2",
-        "es-abstract": "^1.7.0"
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.18.0-next.2",
+        "get-intrinsic": "^1.1.1",
+        "is-string": "^1.0.5"
       }
     },
     "array-unique": {
@@ -784,6 +728,17 @@
       "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/array-unique/-/array-unique-0.3.2.tgz",
       "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
       "dev": true
+    },
+    "array.prototype.flat": {
+      "version": "1.2.4",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/array.prototype.flat/-/array.prototype.flat-1.2.4.tgz",
+      "integrity": "sha1-bvY4tDMSvUAbTGGZ/ex+LcnpoSM=",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.0",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.18.0-next.1"
+      }
     },
     "asn1": {
       "version": "0.2.4",
@@ -818,9 +773,9 @@
       "dev": true
     },
     "async-limiter": {
-      "version": "1.0.0",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/async-limiter/-/async-limiter-1.0.0.tgz",
-      "integrity": "sha1-ePrtjD0HSrgfIrTphdeehzj3IPg=",
+      "version": "1.0.1",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/async-limiter/-/async-limiter-1.0.1.tgz",
+      "integrity": "sha1-3TeelPDbgxCwgpH51kwyCXZmF/0=",
       "dev": true
     },
     "asynckit": {
@@ -842,32 +797,33 @@
       "dev": true
     },
     "aws4": {
-      "version": "1.8.0",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/aws4/-/aws4-1.8.0.tgz",
-      "integrity": "sha1-8OAD2cqef1nHpQiUXXsu+aBKVC8=",
+      "version": "1.11.0",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/aws4/-/aws4-1.11.0.tgz",
+      "integrity": "sha1-1h9G2DslGSUOJ4Ta9bCUeai0HFk=",
       "dev": true
     },
     "babel-jest": {
-      "version": "24.8.0",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/babel-jest/-/babel-jest-24.8.0.tgz",
-      "integrity": "sha1-XBX/KyjiCw9F30P+a38qrpPbpYk=",
+      "version": "24.9.0",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/babel-jest/-/babel-jest-24.9.0.tgz",
+      "integrity": "sha1-P8Mny4RnuJ0U17xw4xUQSng8zVQ=",
       "dev": true,
       "requires": {
-        "@jest/transform": "^24.8.0",
-        "@jest/types": "^24.8.0",
+        "@jest/transform": "^24.9.0",
+        "@jest/types": "^24.9.0",
         "@types/babel__core": "^7.1.0",
         "babel-plugin-istanbul": "^5.1.0",
-        "babel-preset-jest": "^24.6.0",
+        "babel-preset-jest": "^24.9.0",
         "chalk": "^2.4.2",
         "slash": "^2.0.0"
       }
     },
     "babel-plugin-istanbul": {
-      "version": "5.1.4",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/babel-plugin-istanbul/-/babel-plugin-istanbul-5.1.4.tgz",
-      "integrity": "sha1-hB0WuaWO60B6DdzmIroC/oenUro=",
+      "version": "5.2.0",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/babel-plugin-istanbul/-/babel-plugin-istanbul-5.2.0.tgz",
+      "integrity": "sha1-30reg9iXqS3wacTZolzyZxKTyFQ=",
       "dev": true,
       "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
         "find-up": "^3.0.0",
         "istanbul-lib-instrument": "^3.3.0",
         "test-exclude": "^5.2.3"
@@ -893,9 +849,9 @@
           }
         },
         "p-limit": {
-          "version": "2.2.0",
-          "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/p-limit/-/p-limit-2.2.0.tgz",
-          "integrity": "sha1-QXyZQeYCepq8ulCS3SkE4lW1+8I=",
+          "version": "2.3.0",
+          "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/p-limit/-/p-limit-2.3.0.tgz",
+          "integrity": "sha1-PdM8ZHohT9//2DWTPrCG2g3CHbE=",
           "dev": true,
           "requires": {
             "p-try": "^2.0.0"
@@ -919,22 +875,22 @@
       }
     },
     "babel-plugin-jest-hoist": {
-      "version": "24.6.0",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-24.6.0.tgz",
-      "integrity": "sha1-9/f3rRUO6W16Xo4sXagxlXnngBk=",
+      "version": "24.9.0",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-24.9.0.tgz",
+      "integrity": "sha1-T4NwketAfgFEfIhDy+xUbQAC11Y=",
       "dev": true,
       "requires": {
         "@types/babel__traverse": "^7.0.6"
       }
     },
     "babel-preset-jest": {
-      "version": "24.6.0",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/babel-preset-jest/-/babel-preset-jest-24.6.0.tgz",
-      "integrity": "sha1-ZvBhNu786HeXU5wNY/F2nMORWYQ=",
+      "version": "24.9.0",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/babel-preset-jest/-/babel-preset-jest-24.9.0.tgz",
+      "integrity": "sha1-GStSHiIX+x0fZ89z9wwzZlCtPNw=",
       "dev": true,
       "requires": {
         "@babel/plugin-syntax-object-rest-spread": "^7.0.0",
-        "babel-plugin-jest-hoist": "^24.6.0"
+        "babel-plugin-jest-hoist": "^24.9.0"
       }
     },
     "balanced-match": {
@@ -1007,6 +963,16 @@
         "tweetnacl": "^0.14.3"
       }
     },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha1-EDU8npRTNLwFEabZCzj7x8nFBN8=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -1047,9 +1013,9 @@
       }
     },
     "browser-process-hrtime": {
-      "version": "0.1.3",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/browser-process-hrtime/-/browser-process-hrtime-0.1.3.tgz",
-      "integrity": "sha1-YW8A+u8d9+wbW/nP4r3DFw8mx7Q=",
+      "version": "1.0.0",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz",
+      "integrity": "sha1-PJtLfXgsgSHlbxAQbYTA0P/JRiY=",
       "dev": true
     },
     "browser-resolve": {
@@ -1069,10 +1035,23 @@
         }
       }
     },
+    "browserslist": {
+      "version": "4.16.3",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/browserslist/-/browserslist-4.16.3.tgz",
+      "integrity": "sha1-NAqkaUDX24eHSFZ8XeokpI3fNxc=",
+      "dev": true,
+      "requires": {
+        "caniuse-lite": "^1.0.30001181",
+        "colorette": "^1.2.1",
+        "electron-to-chromium": "^1.3.649",
+        "escalade": "^3.1.1",
+        "node-releases": "^1.1.70"
+      }
+    },
     "bser": {
-      "version": "2.1.0",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/bser/-/bser-2.1.0.tgz",
-      "integrity": "sha1-Zfx4S/f4fACblzwS22VGkC+px7U=",
+      "version": "2.1.1",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/bser/-/bser-2.1.1.tgz",
+      "integrity": "sha1-5nh9og7OnQeZhTPP2d5vXDj0vAU=",
       "dev": true,
       "requires": {
         "node-int64": "^0.4.0"
@@ -1101,6 +1080,16 @@
         "unset-value": "^1.0.0"
       }
     },
+    "call-bind": {
+      "version": "1.0.2",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/call-bind/-/call-bind-1.0.2.tgz",
+      "integrity": "sha1-sdTonmiBGcPJqQOtMKuy9qkZvjw=",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1",
+        "get-intrinsic": "^1.0.2"
+      }
+    },
     "callsites": {
       "version": "3.1.0",
       "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/callsites/-/callsites-3.1.0.tgz",
@@ -1111,6 +1100,12 @@
       "version": "5.3.1",
       "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/camelcase/-/camelcase-5.3.1.tgz",
       "integrity": "sha1-48mzFWnhBoEd8kL3FXJaH0xJQyA=",
+      "dev": true
+    },
+    "caniuse-lite": {
+      "version": "1.0.30001204",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/caniuse-lite/-/caniuse-lite-1.0.30001204.tgz",
+      "integrity": "sha1-JWyFcJo0jsTRdehHo7UVxm558qo=",
       "dev": true
     },
     "capture-exit": {
@@ -1208,26 +1203,48 @@
       "dev": true
     },
     "cliui": {
-      "version": "4.1.0",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/cliui/-/cliui-4.1.0.tgz",
-      "integrity": "sha1-NIQi2+gtgAswIu709qwQvy5NG0k=",
+      "version": "5.0.0",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/cliui/-/cliui-5.0.0.tgz",
+      "integrity": "sha1-3u/P2y6AB4SqNPRvoI4GhRx7u8U=",
       "dev": true,
       "requires": {
-        "string-width": "^2.1.1",
-        "strip-ansi": "^4.0.0",
-        "wrap-ansi": "^2.0.0"
+        "string-width": "^3.1.0",
+        "strip-ansi": "^5.2.0",
+        "wrap-ansi": "^5.1.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha1-i5+PCM8ay4Q3Vqg5yox+MWjFGZc=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha1-InZ74htirxCBV0MG9prFG2IgOWE=",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha1-jJpTb+tq/JYr36WxBKUJHBrZwK4=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        }
       }
     },
     "co": {
       "version": "4.6.0",
       "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/co/-/co-4.6.0.tgz",
       "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
-      "dev": true
-    },
-    "code-point-at": {
-      "version": "1.1.0",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/code-point-at/-/code-point-at-1.1.0.tgz",
-      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
       "dev": true
     },
     "collection-visit": {
@@ -1255,6 +1272,12 @@
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
     },
+    "colorette": {
+      "version": "1.2.2",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/colorette/-/colorette-1.2.2.tgz",
+      "integrity": "sha1-y8x51emcrqLb8Q6zom/Ys+as+pQ=",
+      "dev": true
+    },
     "combined-stream": {
       "version": "1.0.8",
       "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -1263,13 +1286,6 @@
       "requires": {
         "delayed-stream": "~1.0.0"
       }
-    },
-    "commander": {
-      "version": "2.20.0",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/commander/-/commander-2.20.0.tgz",
-      "integrity": "sha1-1YuytcHuj4ew00ACfp6U4iLFpCI=",
-      "dev": true,
-      "optional": true
     },
     "component-emitter": {
       "version": "1.3.0",
@@ -1283,6 +1299,12 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
+    "confusing-browser-globals": {
+      "version": "1.0.10",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/confusing-browser-globals/-/confusing-browser-globals-1.0.10.tgz",
+      "integrity": "sha1-MNHn89G4grJexJM9HRraw1PSClk=",
+      "dev": true
+    },
     "contains-path": {
       "version": "0.1.0",
       "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/contains-path/-/contains-path-0.1.0.tgz",
@@ -1290,9 +1312,9 @@
       "dev": true
     },
     "convert-source-map": {
-      "version": "1.6.0",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/convert-source-map/-/convert-source-map-1.6.0.tgz",
-      "integrity": "sha1-UbU3qMQ+DwTewZk7/83VBOdYrCA=",
+      "version": "1.7.0",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/convert-source-map/-/convert-source-map-1.7.0.tgz",
+      "integrity": "sha1-F6LLiC1/d9NJBYXizmxSRCSjpEI=",
       "dev": true,
       "requires": {
         "safe-buffer": "~5.1.1"
@@ -1324,15 +1346,15 @@
       }
     },
     "cssom": {
-      "version": "0.3.6",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/cssom/-/cssom-0.3.6.tgz",
-      "integrity": "sha1-+FIGzuBO+oQfPFmCp0uparINZa0=",
+      "version": "0.3.8",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/cssom/-/cssom-0.3.8.tgz",
+      "integrity": "sha1-nxJ29bK0Y/IRTT8sdSUK+MGjb0o=",
       "dev": true
     },
     "cssstyle": {
-      "version": "1.2.2",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/cssstyle/-/cssstyle-1.2.2.tgz",
-      "integrity": "sha1-Qn6k1YWxhiT2/b+d56Kho7pxMHc=",
+      "version": "1.4.0",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/cssstyle/-/cssstyle-1.4.0.tgz",
+      "integrity": "sha1-nTEyginTxWXGHlhrAgQaKPzNzPE=",
       "dev": true,
       "requires": {
         "cssom": "0.3.x"
@@ -1359,15 +1381,32 @@
       },
       "dependencies": {
         "whatwg-url": {
-          "version": "7.0.0",
-          "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/whatwg-url/-/whatwg-url-7.0.0.tgz",
-          "integrity": "sha1-/ekm+lSlmfOt+C3/Jan3vgLcbt0=",
+          "version": "7.1.0",
+          "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/whatwg-url/-/whatwg-url-7.1.0.tgz",
+          "integrity": "sha1-wsSS8eymEpiO/T0iZr4bn8YXDQY=",
           "dev": true,
           "requires": {
             "lodash.sortby": "^4.7.0",
             "tr46": "^1.0.1",
             "webidl-conversions": "^4.0.2"
           }
+        }
+      }
+    },
+    "debug": {
+      "version": "2.6.9",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+      "dev": true,
+      "requires": {
+        "ms": "2.0.0"
+      },
+      "dependencies": {
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
         }
       }
     },
@@ -1465,9 +1504,9 @@
       "dev": true
     },
     "diff-sequences": {
-      "version": "24.3.0",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/diff-sequences/-/diff-sequences-24.3.0.tgz",
-      "integrity": "sha1-DyDood8avdr02cImaAlS5kEYuXU=",
+      "version": "24.9.0",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/diff-sequences/-/diff-sequences-24.9.0.tgz",
+      "integrity": "sha1-VxXWJE4qpl9Iu6C8ly2wsLEelbU=",
       "dev": true
     },
     "doctrine": {
@@ -1498,6 +1537,12 @@
         "safer-buffer": "^2.1.0"
       }
     },
+    "electron-to-chromium": {
+      "version": "1.3.696",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/electron-to-chromium/-/electron-to-chromium-1.3.696.tgz",
+      "integrity": "sha1-84SFZE/yPVWVXZ1okBBRxuctHBQ=",
+      "dev": true
+    },
     "emoji-regex": {
       "version": "7.0.3",
       "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/emoji-regex/-/emoji-regex-7.0.3.tgz",
@@ -1505,9 +1550,9 @@
       "dev": true
     },
     "end-of-stream": {
-      "version": "1.4.1",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/end-of-stream/-/end-of-stream-1.4.1.tgz",
-      "integrity": "sha1-7SljTRm6ukY7bOa4CjchPqtx7EM=",
+      "version": "1.4.4",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "integrity": "sha1-WuZKX0UFe682JuwU2gyl5LJDHrA=",
       "dev": true,
       "requires": {
         "once": "^1.4.0"
@@ -1523,29 +1568,45 @@
       }
     },
     "es-abstract": {
-      "version": "1.13.0",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/es-abstract/-/es-abstract-1.13.0.tgz",
-      "integrity": "sha1-rIYUX91QmdjdSVWMy6Lq+biOJOk=",
+      "version": "1.18.0",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/es-abstract/-/es-abstract-1.18.0.tgz",
+      "integrity": "sha1-q4CzWe7Lft5MKYAAOQvFrD7HtaQ=",
       "dev": true,
       "requires": {
-        "es-to-primitive": "^1.2.0",
+        "call-bind": "^1.0.2",
+        "es-to-primitive": "^1.2.1",
         "function-bind": "^1.1.1",
+        "get-intrinsic": "^1.1.1",
         "has": "^1.0.3",
-        "is-callable": "^1.1.4",
-        "is-regex": "^1.0.4",
-        "object-keys": "^1.0.12"
+        "has-symbols": "^1.0.2",
+        "is-callable": "^1.2.3",
+        "is-negative-zero": "^2.0.1",
+        "is-regex": "^1.1.2",
+        "is-string": "^1.0.5",
+        "object-inspect": "^1.9.0",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.2",
+        "string.prototype.trimend": "^1.0.4",
+        "string.prototype.trimstart": "^1.0.4",
+        "unbox-primitive": "^1.0.0"
       }
     },
     "es-to-primitive": {
-      "version": "1.2.0",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
-      "integrity": "sha1-7fckeAM0VujdqO8J4ArZZQcH83c=",
+      "version": "1.2.1",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+      "integrity": "sha1-5VzUyc3BiLzvsDs2bHNjI/xciYo=",
       "dev": true,
       "requires": {
         "is-callable": "^1.1.4",
         "is-date-object": "^1.0.1",
         "is-symbol": "^1.0.2"
       }
+    },
+    "escalade": {
+      "version": "3.1.1",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/escalade/-/escalade-3.1.1.tgz",
+      "integrity": "sha1-2M/ccACWXFoBdLSoLqpcBVJ0LkA=",
+      "dev": true
     },
     "escape-string-regexp": {
       "version": "1.0.5",
@@ -1554,31 +1615,16 @@
       "dev": true
     },
     "escodegen": {
-      "version": "1.11.1",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/escodegen/-/escodegen-1.11.1.tgz",
-      "integrity": "sha1-xIX/jWtM24nif0qFbpHxGEAcpRA=",
+      "version": "1.14.3",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/escodegen/-/escodegen-1.14.3.tgz",
+      "integrity": "sha1-TnuB+6YVgdyXWC7XjKt/Do1j9QM=",
       "dev": true,
       "requires": {
-        "esprima": "^3.1.3",
+        "esprima": "^4.0.1",
         "estraverse": "^4.2.0",
         "esutils": "^2.0.2",
         "optionator": "^0.8.1",
         "source-map": "~0.6.1"
-      },
-      "dependencies": {
-        "esprima": {
-          "version": "3.1.3",
-          "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/esprima/-/esprima-3.1.3.tgz",
-          "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
-          "dev": true
-        },
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
-          "dev": true,
-          "optional": true
-        }
       }
     },
     "eslint": {
@@ -1673,14 +1719,14 @@
       }
     },
     "eslint-config-airbnb-base": {
-      "version": "13.1.0",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/eslint-config-airbnb-base/-/eslint-config-airbnb-base-13.1.0.tgz",
-      "integrity": "sha1-taG0gLgN+tFkM9bErYTmYFBSwFw=",
+      "version": "13.2.0",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/eslint-config-airbnb-base/-/eslint-config-airbnb-base-13.2.0.tgz",
+      "integrity": "sha1-9uqBRZ/03sLdogDDXx2PdBnVeUM=",
       "dev": true,
       "requires": {
-        "eslint-restricted-globals": "^0.1.1",
+        "confusing-browser-globals": "^1.0.5",
         "object.assign": "^4.1.0",
-        "object.entries": "^1.0.4"
+        "object.entries": "^1.1.0"
       }
     },
     "eslint-config-prettier": {
@@ -1693,87 +1739,46 @@
       }
     },
     "eslint-import-resolver-node": {
-      "version": "0.3.2",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.2.tgz",
-      "integrity": "sha1-WPFfuDm40FdsqYBBNHaqskcttmo=",
+      "version": "0.3.4",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.4.tgz",
+      "integrity": "sha1-hf+oGULCUBLYIxCW3fZ5wDBCxxc=",
       "dev": true,
       "requires": {
         "debug": "^2.6.9",
-        "resolve": "^1.5.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "dev": true
-        }
+        "resolve": "^1.13.1"
       }
     },
     "eslint-module-utils": {
-      "version": "2.4.0",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/eslint-module-utils/-/eslint-module-utils-2.4.0.tgz",
-      "integrity": "sha1-i5NJnpsA6rgMy2YU5p8DZ46E4Jo=",
+      "version": "2.6.0",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/eslint-module-utils/-/eslint-module-utils-2.6.0.tgz",
+      "integrity": "sha1-V569CU9Wr3eX0ZyYZsnJSGYpv6Y=",
       "dev": true,
       "requires": {
-        "debug": "^2.6.8",
+        "debug": "^2.6.9",
         "pkg-dir": "^2.0.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "dev": true
-        }
       }
     },
     "eslint-plugin-import": {
-      "version": "2.17.3",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/eslint-plugin-import/-/eslint-plugin-import-2.17.3.tgz",
-      "integrity": "sha1-AFSLRDTBj666ugSySuYZjygN4Yk=",
+      "version": "2.22.1",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/eslint-plugin-import/-/eslint-plugin-import-2.22.1.tgz",
+      "integrity": "sha1-CJbH5qDPRBCaLZe5WQPCu2iddwI=",
       "dev": true,
       "requires": {
-        "array-includes": "^3.0.3",
+        "array-includes": "^3.1.1",
+        "array.prototype.flat": "^1.2.3",
         "contains-path": "^0.1.0",
         "debug": "^2.6.9",
         "doctrine": "1.5.0",
-        "eslint-import-resolver-node": "^0.3.2",
-        "eslint-module-utils": "^2.4.0",
+        "eslint-import-resolver-node": "^0.3.4",
+        "eslint-module-utils": "^2.6.0",
         "has": "^1.0.3",
-        "lodash": "^4.17.11",
         "minimatch": "^3.0.4",
+        "object.values": "^1.1.1",
         "read-pkg-up": "^2.0.0",
-        "resolve": "^1.11.0"
+        "resolve": "^1.17.0",
+        "tsconfig-paths": "^3.9.0"
       },
       "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
         "doctrine": {
           "version": "1.5.0",
           "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/doctrine/-/doctrine-1.5.0.tgz",
@@ -1783,29 +1788,17 @@
             "esutils": "^2.0.2",
             "isarray": "^1.0.0"
           }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "dev": true
         }
       }
     },
     "eslint-plugin-prettier": {
-      "version": "3.1.0",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/eslint-plugin-prettier/-/eslint-plugin-prettier-3.1.0.tgz",
-      "integrity": "sha1-hpUYj5XaqTsNxUskk0fKO3nEaG0=",
+      "version": "3.3.1",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/eslint-plugin-prettier/-/eslint-plugin-prettier-3.3.1.tgz",
+      "integrity": "sha1-cHnPoklweJBQEeb4Lo3YRT0Tcbc=",
       "dev": true,
       "requires": {
         "prettier-linter-helpers": "^1.0.0"
       }
-    },
-    "eslint-restricted-globals": {
-      "version": "0.1.1",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/eslint-restricted-globals/-/eslint-restricted-globals-0.1.1.tgz",
-      "integrity": "sha1-NfDVy8ZMLj7WLpO0saevBbp+1Nc=",
-      "dev": true
     },
     "eslint-utils": {
       "version": "1.3.1",
@@ -1867,9 +1860,9 @@
       "dev": true
     },
     "exec-sh": {
-      "version": "0.3.2",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/exec-sh/-/exec-sh-0.3.2.tgz",
-      "integrity": "sha1-ZzjeLrfI5nHQNmrqCw24xvfXORs=",
+      "version": "0.3.5",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/exec-sh/-/exec-sh-0.3.5.tgz",
+      "integrity": "sha1-G0a9a8v1T9wekmpPPZASbULOw98=",
       "dev": true
     },
     "execa": {
@@ -1908,15 +1901,6 @@
         "to-regex": "^3.0.1"
       },
       "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
         "define-property": {
           "version": "0.2.5",
           "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/define-property/-/define-property-0.2.5.tgz",
@@ -1934,27 +1918,21 @@
           "requires": {
             "is-extendable": "^0.1.0"
           }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "dev": true
         }
       }
     },
     "expect": {
-      "version": "24.8.0",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/expect/-/expect-24.8.0.tgz",
-      "integrity": "sha1-Rx+Owla3thKcolJLKmLwMN84cY0=",
+      "version": "24.9.0",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/expect/-/expect-24.9.0.tgz",
+      "integrity": "sha1-t1FltIFwdPpKFXeU9G/p8boVtso=",
       "dev": true,
       "requires": {
-        "@jest/types": "^24.8.0",
+        "@jest/types": "^24.9.0",
         "ansi-styles": "^3.2.0",
-        "jest-get-type": "^24.8.0",
-        "jest-matcher-utils": "^24.8.0",
-        "jest-message-util": "^24.8.0",
-        "jest-regex-util": "^24.3.0"
+        "jest-get-type": "^24.9.0",
+        "jest-matcher-utils": "^24.9.0",
+        "jest-message-util": "^24.9.0",
+        "jest-regex-util": "^24.9.0"
       }
     },
     "extend": {
@@ -2091,12 +2069,12 @@
       "dev": true
     },
     "fb-watchman": {
-      "version": "2.0.0",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/fb-watchman/-/fb-watchman-2.0.0.tgz",
-      "integrity": "sha1-VOmr99+i8mzZsWNsWIwa/AXeXVg=",
+      "version": "2.0.1",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/fb-watchman/-/fb-watchman-2.0.1.tgz",
+      "integrity": "sha1-/IT7OdJwnPP/bXQ3BhV7tXCKioU=",
       "dev": true,
       "requires": {
-        "bser": "^2.0.0"
+        "bser": "2.1.1"
       }
     },
     "figures": {
@@ -2116,6 +2094,13 @@
       "requires": {
         "flat-cache": "^2.0.1"
       }
+    },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha1-VTp7hEb/b2hDWcRF8eN6BdrMM90=",
+      "dev": true,
+      "optional": true
     },
     "fill-range": {
       "version": "4.0.0",
@@ -2166,6 +2151,15 @@
       "integrity": "sha1-VRIrZTbqSWtLRIk+4mCBQdENmRY=",
       "dev": true
     },
+    "for-each": {
+      "version": "0.3.3",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/for-each/-/for-each-0.3.3.tgz",
+      "integrity": "sha1-abRH6IoKXTLD5whPPxcQA0shN24=",
+      "dev": true,
+      "requires": {
+        "is-callable": "^1.1.3"
+      }
+    },
     "for-in": {
       "version": "1.0.2",
       "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/for-in/-/for-in-1.0.2.tgz",
@@ -2205,532 +2199,14 @@
       "dev": true
     },
     "fsevents": {
-      "version": "1.2.9",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/fsevents/-/fsevents-1.2.9.tgz",
-      "integrity": "sha1-P17WZYPM1vQAtaANtvfoYTY+OI8=",
+      "version": "1.2.13",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/fsevents/-/fsevents-1.2.13.tgz",
+      "integrity": "sha1-8yXLBFVZJCi88Rs4M3DvcOO/zDg=",
       "dev": true,
       "optional": true,
       "requires": {
-        "nan": "^2.12.1",
-        "node-pre-gyp": "^0.12.0"
-      },
-      "dependencies": {
-        "abbrev": {
-          "version": "1.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "ansi-regex": {
-          "version": "2.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "aproba": {
-          "version": "1.2.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "are-we-there-yet": {
-          "version": "1.1.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "delegates": "^1.0.0",
-            "readable-stream": "^2.0.6"
-          }
-        },
-        "balanced-match": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "brace-expansion": {
-          "version": "1.1.11",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "balanced-match": "^1.0.0",
-            "concat-map": "0.0.1"
-          }
-        },
-        "chownr": {
-          "version": "1.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "code-point-at": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "concat-map": {
-          "version": "0.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "console-control-strings": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "core-util-is": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "debug": {
-          "version": "4.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "deep-extend": {
-          "version": "0.6.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "delegates": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "detect-libc": {
-          "version": "1.0.3",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "fs-minipass": {
-          "version": "1.2.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "minipass": "^2.2.1"
-          }
-        },
-        "fs.realpath": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "gauge": {
-          "version": "2.7.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "aproba": "^1.0.3",
-            "console-control-strings": "^1.0.0",
-            "has-unicode": "^2.0.0",
-            "object-assign": "^4.1.0",
-            "signal-exit": "^3.0.0",
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1",
-            "wide-align": "^1.1.0"
-          }
-        },
-        "glob": {
-          "version": "7.1.3",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        },
-        "has-unicode": {
-          "version": "2.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "iconv-lite": {
-          "version": "0.4.24",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "safer-buffer": ">= 2.1.2 < 3"
-          }
-        },
-        "ignore-walk": {
-          "version": "3.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "minimatch": "^3.0.4"
-          }
-        },
-        "inflight": {
-          "version": "1.0.6",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "once": "^1.3.0",
-            "wrappy": "1"
-          }
-        },
-        "inherits": {
-          "version": "2.0.3",
-          "bundled": true,
-          "dev": true
-        },
-        "ini": {
-          "version": "1.3.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "number-is-nan": "^1.0.0"
-          }
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "minimatch": {
-          "version": "3.0.4",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "brace-expansion": "^1.1.7"
-          }
-        },
-        "minimist": {
-          "version": "0.0.8",
-          "bundled": true,
-          "dev": true
-        },
-        "minipass": {
-          "version": "2.3.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "safe-buffer": "^5.1.2",
-            "yallist": "^3.0.0"
-          }
-        },
-        "minizlib": {
-          "version": "1.2.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "minipass": "^2.2.1"
-          }
-        },
-        "mkdirp": {
-          "version": "0.5.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "minimist": "0.0.8"
-          }
-        },
-        "ms": {
-          "version": "2.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "needle": {
-          "version": "2.3.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "debug": "^4.1.0",
-            "iconv-lite": "^0.4.4",
-            "sax": "^1.2.4"
-          }
-        },
-        "node-pre-gyp": {
-          "version": "0.12.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "detect-libc": "^1.0.2",
-            "mkdirp": "^0.5.1",
-            "needle": "^2.2.1",
-            "nopt": "^4.0.1",
-            "npm-packlist": "^1.1.6",
-            "npmlog": "^4.0.2",
-            "rc": "^1.2.7",
-            "rimraf": "^2.6.1",
-            "semver": "^5.3.0",
-            "tar": "^4"
-          }
-        },
-        "nopt": {
-          "version": "4.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "abbrev": "1",
-            "osenv": "^0.1.4"
-          }
-        },
-        "npm-bundled": {
-          "version": "1.0.6",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "npm-packlist": {
-          "version": "1.4.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "ignore-walk": "^3.0.1",
-            "npm-bundled": "^1.0.1"
-          }
-        },
-        "npmlog": {
-          "version": "4.1.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "are-we-there-yet": "~1.1.2",
-            "console-control-strings": "~1.1.0",
-            "gauge": "~2.7.3",
-            "set-blocking": "~2.0.0"
-          }
-        },
-        "number-is-nan": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "once": {
-          "version": "1.4.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "wrappy": "1"
-          }
-        },
-        "os-homedir": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "os-tmpdir": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "osenv": {
-          "version": "0.1.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "os-homedir": "^1.0.0",
-            "os-tmpdir": "^1.0.0"
-          }
-        },
-        "path-is-absolute": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "process-nextick-args": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "rc": {
-          "version": "1.2.8",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "deep-extend": "^0.6.0",
-            "ini": "~1.3.0",
-            "minimist": "^1.2.0",
-            "strip-json-comments": "~2.0.1"
-          },
-          "dependencies": {
-            "minimist": {
-              "version": "1.2.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            }
-          }
-        },
-        "readable-stream": {
-          "version": "2.3.6",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "rimraf": {
-          "version": "2.6.3",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "glob": "^7.1.3"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.1.2",
-          "bundled": true,
-          "dev": true
-        },
-        "safer-buffer": {
-          "version": "2.1.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "sax": {
-          "version": "1.2.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "semver": {
-          "version": "5.7.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "set-blocking": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "signal-exit": {
-          "version": "3.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "string-width": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
-          }
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^2.0.0"
-          }
-        },
-        "strip-json-comments": {
-          "version": "2.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "tar": {
-          "version": "4.4.8",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "chownr": "^1.1.1",
-            "fs-minipass": "^1.2.5",
-            "minipass": "^2.3.4",
-            "minizlib": "^1.1.1",
-            "mkdirp": "^0.5.0",
-            "safe-buffer": "^5.1.2",
-            "yallist": "^3.0.2"
-          }
-        },
-        "util-deprecate": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "wide-align": {
-          "version": "1.1.3",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "string-width": "^1.0.2 || 2"
-          }
-        },
-        "wrappy": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "yallist": {
-          "version": "3.0.3",
-          "bundled": true,
-          "dev": true
-        }
+        "bindings": "^1.5.0",
+        "nan": "^2.12.1"
       }
     },
     "function-bind": {
@@ -2745,16 +2221,33 @@
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true
     },
+    "gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha1-MqbudsPX9S1GsrGuXZP+qFgKJeA=",
+      "dev": true
+    },
     "get-caller-file": {
-      "version": "1.0.3",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/get-caller-file/-/get-caller-file-1.0.3.tgz",
-      "integrity": "sha1-+Xj6TJDR3+f/LWvtoqUV5xO9z0o=",
+      "version": "2.0.5",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha1-T5RBKoLbMvNuOwuXQfipf+sDH34=",
       "dev": true
     },
     "get-func-name": {
       "version": "2.0.0",
       "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/get-func-name/-/get-func-name-2.0.0.tgz",
       "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE="
+    },
+    "get-intrinsic": {
+      "version": "1.1.1",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
+      "integrity": "sha1-FfWfN2+FXERpY5SPDSTNNje0q8Y=",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.1"
+      }
     },
     "get-stdin": {
       "version": "6.0.0",
@@ -2807,9 +2300,9 @@
       "dev": true
     },
     "graceful-fs": {
-      "version": "4.1.15",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/graceful-fs/-/graceful-fs-4.1.15.tgz",
-      "integrity": "sha1-/7cD4QZuig7qpMi4C6klPu77+wA=",
+      "version": "4.2.6",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/graceful-fs/-/graceful-fs-4.2.6.tgz",
+      "integrity": "sha1-/wQLKwhTsjw9MQJ1I3BvGIXXa+4=",
       "dev": true
     },
     "growly": {
@@ -2818,26 +2311,6 @@
       "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
       "dev": true
     },
-    "handlebars": {
-      "version": "4.1.2",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/handlebars/-/handlebars-4.1.2.tgz",
-      "integrity": "sha1-trN8HO0DBrIh4JT8eso+wjsTG2c=",
-      "dev": true,
-      "requires": {
-        "neo-async": "^2.6.0",
-        "optimist": "^0.6.1",
-        "source-map": "^0.6.1",
-        "uglify-js": "^3.1.4"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
-          "dev": true
-        }
-      }
-    },
     "har-schema": {
       "version": "2.0.0",
       "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/har-schema/-/har-schema-2.0.0.tgz",
@@ -2845,13 +2318,33 @@
       "dev": true
     },
     "har-validator": {
-      "version": "5.1.3",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/har-validator/-/har-validator-5.1.3.tgz",
-      "integrity": "sha1-HvievT5JllV2de7ZiTEQ3DUPoIA=",
+      "version": "5.1.5",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/har-validator/-/har-validator-5.1.5.tgz",
+      "integrity": "sha1-HwgDufjLIMD6E4It8ezds2veHv0=",
       "dev": true,
       "requires": {
-        "ajv": "^6.5.5",
+        "ajv": "^6.12.3",
         "har-schema": "^2.0.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "6.12.6",
+          "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/ajv/-/ajv-6.12.6.tgz",
+          "integrity": "sha1-uvWmLoArB9l3A0WG+MO69a3ybfQ=",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "fast-deep-equal": {
+          "version": "3.1.3",
+          "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+          "integrity": "sha1-On1WtVnWy8PrUSMlJE5hmmXGxSU=",
+          "dev": true
+        }
       }
     },
     "has": {
@@ -2863,6 +2356,12 @@
         "function-bind": "^1.1.1"
       }
     },
+    "has-bigints": {
+      "version": "1.0.1",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/has-bigints/-/has-bigints-1.0.1.tgz",
+      "integrity": "sha1-ZP5qywIGc+O3jbA1pa9pqp0HsRM=",
+      "dev": true
+    },
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/has-flag/-/has-flag-3.0.0.tgz",
@@ -2870,9 +2369,9 @@
       "dev": true
     },
     "has-symbols": {
-      "version": "1.0.0",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/has-symbols/-/has-symbols-1.0.0.tgz",
-      "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
+      "version": "1.0.2",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/has-symbols/-/has-symbols-1.0.2.tgz",
+      "integrity": "sha1-Fl0wcMADCXUqEjakeTMeOsVvFCM=",
       "dev": true
     },
     "has-value": {
@@ -2908,9 +2407,9 @@
       }
     },
     "hosted-git-info": {
-      "version": "2.7.1",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
-      "integrity": "sha1-l/I2l3vW4SVAiTD/bePuxigewEc=",
+      "version": "2.8.8",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
+      "integrity": "sha1-dTm9S8Hg4KiVgVouAmJCCxKFhIg=",
       "dev": true
     },
     "html-encoding-sniffer": {
@@ -2921,6 +2420,12 @@
       "requires": {
         "whatwg-encoding": "^1.0.1"
       }
+    },
+    "html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha1-39YAJ9o2o238viNiYsAKWCJoFFM=",
+      "dev": true
     },
     "http-signature": {
       "version": "1.2.0",
@@ -2988,9 +2493,9 @@
           }
         },
         "p-limit": {
-          "version": "2.2.0",
-          "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/p-limit/-/p-limit-2.2.0.tgz",
-          "integrity": "sha1-QXyZQeYCepq8ulCS3SkE4lW1+8I=",
+          "version": "2.3.0",
+          "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/p-limit/-/p-limit-2.3.0.tgz",
+          "integrity": "sha1-PdM8ZHohT9//2DWTPrCG2g3CHbE=",
           "dev": true,
           "requires": {
             "p-try": "^2.0.0"
@@ -3091,12 +2596,6 @@
         "loose-envify": "^1.0.0"
       }
     },
-    "invert-kv": {
-      "version": "2.0.0",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/invert-kv/-/invert-kv-2.0.0.tgz",
-      "integrity": "sha1-c5P1r6Weyf9fZ6J2INEcIm4+7AI=",
-      "dev": true
-    },
     "is-accessor-descriptor": {
       "version": "0.1.6",
       "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
@@ -3123,6 +2622,21 @@
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
       "dev": true
     },
+    "is-bigint": {
+      "version": "1.0.1",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/is-bigint/-/is-bigint-1.0.1.tgz",
+      "integrity": "sha1-aSMFHfy8dkJ4VAuc4OazITql68I=",
+      "dev": true
+    },
+    "is-boolean-object": {
+      "version": "1.1.0",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/is-boolean-object/-/is-boolean-object-1.1.0.tgz",
+      "integrity": "sha1-4qqtOjqPyjTCj27uE1sVbtJYf/A=",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.0"
+      }
+    },
     "is-buffer": {
       "version": "1.1.6",
       "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/is-buffer/-/is-buffer-1.1.6.tgz",
@@ -3130,9 +2644,9 @@
       "dev": true
     },
     "is-callable": {
-      "version": "1.1.4",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/is-callable/-/is-callable-1.1.4.tgz",
-      "integrity": "sha1-HhrfIZ4e62hNaR+dagX/DTCiTXU=",
+      "version": "1.2.3",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/is-callable/-/is-callable-1.2.3.tgz",
+      "integrity": "sha1-ix4FALc6HXbHBIdjbzaOUZ3o244=",
       "dev": true
     },
     "is-ci": {
@@ -3142,6 +2656,15 @@
       "dev": true,
       "requires": {
         "ci-info": "^2.0.0"
+      }
+    },
+    "is-core-module": {
+      "version": "2.2.0",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/is-core-module/-/is-core-module-2.2.0.tgz",
+      "integrity": "sha1-lwN+89UiJNhRY/VZeytj2a/tmBo=",
+      "dev": true,
+      "requires": {
+        "has": "^1.0.3"
       }
     },
     "is-data-descriptor": {
@@ -3165,9 +2688,9 @@
       }
     },
     "is-date-object": {
-      "version": "1.0.1",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/is-date-object/-/is-date-object-1.0.1.tgz",
-      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
+      "version": "1.0.2",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/is-date-object/-/is-date-object-1.0.2.tgz",
+      "integrity": "sha1-vac28s2P0G0yhE53Q7+nSUw7/X4=",
       "dev": true
     },
     "is-descriptor": {
@@ -3207,6 +2730,12 @@
       "integrity": "sha1-fRQK3DiarzARqPKipM+m+q3/sRg=",
       "dev": true
     },
+    "is-negative-zero": {
+      "version": "2.0.1",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/is-negative-zero/-/is-negative-zero-2.0.1.tgz",
+      "integrity": "sha1-PedGwY3aIxkkGlNnWQjY92bxHCQ=",
+      "dev": true
+    },
     "is-number": {
       "version": "3.0.0",
       "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/is-number/-/is-number-3.0.0.tgz",
@@ -3227,6 +2756,12 @@
         }
       }
     },
+    "is-number-object": {
+      "version": "1.0.4",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/is-number-object/-/is-number-object-1.0.4.tgz",
+      "integrity": "sha1-NqyV50HPGLKD/B3fXoPaeY4+wZc=",
+      "dev": true
+    },
     "is-plain-object": {
       "version": "2.0.4",
       "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/is-plain-object/-/is-plain-object-2.0.4.tgz",
@@ -3243,12 +2778,13 @@
       "dev": true
     },
     "is-regex": {
-      "version": "1.0.4",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/is-regex/-/is-regex-1.0.4.tgz",
-      "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+      "version": "1.1.2",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/is-regex/-/is-regex-1.1.2.tgz",
+      "integrity": "sha1-gcjr3k2xQvLPHFP8htakV4gmYlE=",
       "dev": true,
       "requires": {
-        "has": "^1.0.1"
+        "call-bind": "^1.0.2",
+        "has-symbols": "^1.0.1"
       }
     },
     "is-stream": {
@@ -3257,13 +2793,19 @@
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
       "dev": true
     },
+    "is-string": {
+      "version": "1.0.5",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/is-string/-/is-string-1.0.5.tgz",
+      "integrity": "sha1-QEk+0ZjvP/R3uMf5L2ROyCpc06Y=",
+      "dev": true
+    },
     "is-symbol": {
-      "version": "1.0.2",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/is-symbol/-/is-symbol-1.0.2.tgz",
-      "integrity": "sha1-oFX2rlcZLK7jKeeoYBGLSXqVDzg=",
+      "version": "1.0.3",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/is-symbol/-/is-symbol-1.0.3.tgz",
+      "integrity": "sha1-OOEBS55jKb4N6dJKQU/XRB7GGTc=",
       "dev": true,
       "requires": {
-        "has-symbols": "^1.0.0"
+        "has-symbols": "^1.0.1"
       }
     },
     "is-typedarray": {
@@ -3329,126 +2871,10 @@
         "semver": "^6.0.0"
       },
       "dependencies": {
-        "@babel/code-frame": {
-          "version": "7.0.0",
-          "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/@babel/code-frame/-/code-frame-7.0.0.tgz",
-          "integrity": "sha1-BuKrGb21NThVWaq7W6WXKUgoAPg=",
-          "dev": true,
-          "requires": {
-            "@babel/highlight": "^7.0.0"
-          }
-        },
-        "@babel/generator": {
-          "version": "7.4.4",
-          "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/@babel/generator/-/generator-7.4.4.tgz",
-          "integrity": "sha1-F0ohXrhD/DksftyqvqqHPebo8EE=",
-          "dev": true,
-          "requires": {
-            "@babel/types": "^7.4.4",
-            "jsesc": "^2.5.1",
-            "lodash": "^4.17.11",
-            "source-map": "^0.5.0",
-            "trim-right": "^1.0.1"
-          }
-        },
-        "@babel/helper-function-name": {
-          "version": "7.1.0",
-          "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
-          "integrity": "sha1-oM6wFoX3M1XUNgwSR/WCv6/I/1M=",
-          "dev": true,
-          "requires": {
-            "@babel/helper-get-function-arity": "^7.0.0",
-            "@babel/template": "^7.1.0",
-            "@babel/types": "^7.0.0"
-          }
-        },
-        "@babel/helper-get-function-arity": {
-          "version": "7.0.0",
-          "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
-          "integrity": "sha1-g1ctQyDipGVyY3NBE8QoaLZOScM=",
-          "dev": true,
-          "requires": {
-            "@babel/types": "^7.0.0"
-          }
-        },
-        "@babel/helper-split-export-declaration": {
-          "version": "7.4.4",
-          "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
-          "integrity": "sha1-/5SJSjQL549T8GrwOLIFxJ2ZNnc=",
-          "dev": true,
-          "requires": {
-            "@babel/types": "^7.4.4"
-          }
-        },
-        "@babel/highlight": {
-          "version": "7.0.0",
-          "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/@babel/highlight/-/highlight-7.0.0.tgz",
-          "integrity": "sha1-9xDDjI1Fjm3ZogGvtjf8t4HOmeQ=",
-          "dev": true,
-          "requires": {
-            "chalk": "^2.0.0",
-            "esutils": "^2.0.2",
-            "js-tokens": "^4.0.0"
-          }
-        },
-        "@babel/template": {
-          "version": "7.4.4",
-          "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/@babel/template/-/template-7.4.4.tgz",
-          "integrity": "sha1-9LiNEiVomgj1vDoXSDVFvp5O0jc=",
-          "dev": true,
-          "requires": {
-            "@babel/code-frame": "^7.0.0",
-            "@babel/parser": "^7.4.4",
-            "@babel/types": "^7.4.4"
-          }
-        },
-        "@babel/traverse": {
-          "version": "7.4.5",
-          "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/@babel/traverse/-/traverse-7.4.5.tgz",
-          "integrity": "sha1-TpLRco/S8Yl9r90yHvv/khVsMhY=",
-          "dev": true,
-          "requires": {
-            "@babel/code-frame": "^7.0.0",
-            "@babel/generator": "^7.4.4",
-            "@babel/helper-function-name": "^7.1.0",
-            "@babel/helper-split-export-declaration": "^7.4.4",
-            "@babel/parser": "^7.4.5",
-            "@babel/types": "^7.4.4",
-            "debug": "^4.1.0",
-            "globals": "^11.1.0",
-            "lodash": "^4.17.11"
-          }
-        },
-        "@babel/types": {
-          "version": "7.4.4",
-          "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/@babel/types/-/types-7.4.4.tgz",
-          "integrity": "sha1-jbnppim7fCk3AAm0t3ntk/5X1fA=",
-          "dev": true,
-          "requires": {
-            "esutils": "^2.0.2",
-            "lodash": "^4.17.11",
-            "to-fast-properties": "^2.0.0"
-          }
-        },
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "js-tokens": {
-          "version": "4.0.0",
-          "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/js-tokens/-/js-tokens-4.0.0.tgz",
-          "integrity": "sha1-GSA/tZmR35jjoocFDUZHzerzJJk=",
-          "dev": true
-        },
         "semver": {
-          "version": "6.1.2",
-          "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/semver/-/semver-6.1.2.tgz",
-          "integrity": "sha1-B5lgOBN2o9ti6y7cijv7EMfP4xg=",
+          "version": "6.3.0",
+          "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha1-7gpkyK9ejO6mdoexM3YeG+y9HT0=",
           "dev": true
         }
       }
@@ -3489,422 +2915,271 @@
       },
       "dependencies": {
         "debug": {
-          "version": "4.1.1",
-          "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
+          "version": "4.3.1",
+          "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha1-8NIpxQXgxtjEmsVT0bE9wYP2su4=",
           "dev": true,
           "requires": {
-            "ms": "^2.1.1"
+            "ms": "2.1.2"
           }
-        },
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
-          "dev": true
         }
       }
     },
     "istanbul-reports": {
-      "version": "2.2.6",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/istanbul-reports/-/istanbul-reports-2.2.6.tgz",
-      "integrity": "sha1-e08mYNgrKTA6j+YJH4ykvwWNoa8=",
+      "version": "2.2.7",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/istanbul-reports/-/istanbul-reports-2.2.7.tgz",
+      "integrity": "sha1-XZOfYjfXtIOTzAlZ6rQM1P0FaTE=",
       "dev": true,
       "requires": {
-        "handlebars": "^4.1.2"
+        "html-escaper": "^2.0.0"
       }
     },
     "jest": {
-      "version": "24.8.0",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/jest/-/jest-24.8.0.tgz",
-      "integrity": "sha1-1d/xmE0NEAIZbpt/Evda8bKAkIE=",
+      "version": "24.9.0",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/jest/-/jest-24.9.0.tgz",
+      "integrity": "sha1-mH0pDAWgi1LFYYjBAC42jtsAcXE=",
       "dev": true,
       "requires": {
         "import-local": "^2.0.0",
-        "jest-cli": "^24.8.0"
+        "jest-cli": "^24.9.0"
       },
       "dependencies": {
         "jest-cli": {
-          "version": "24.8.0",
-          "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/jest-cli/-/jest-cli-24.8.0.tgz",
-          "integrity": "sha1-sHWskUSS7RFPozit5zYqMBaT6Yk=",
+          "version": "24.9.0",
+          "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/jest-cli/-/jest-cli-24.9.0.tgz",
+          "integrity": "sha1-rS3mLQdHLUGcarwwH8QyuYsQ0q8=",
           "dev": true,
           "requires": {
-            "@jest/core": "^24.8.0",
-            "@jest/test-result": "^24.8.0",
-            "@jest/types": "^24.8.0",
+            "@jest/core": "^24.9.0",
+            "@jest/test-result": "^24.9.0",
+            "@jest/types": "^24.9.0",
             "chalk": "^2.0.1",
             "exit": "^0.1.2",
             "import-local": "^2.0.0",
             "is-ci": "^2.0.0",
-            "jest-config": "^24.8.0",
-            "jest-util": "^24.8.0",
-            "jest-validate": "^24.8.0",
+            "jest-config": "^24.9.0",
+            "jest-util": "^24.9.0",
+            "jest-validate": "^24.9.0",
             "prompts": "^2.0.1",
             "realpath-native": "^1.1.0",
-            "yargs": "^12.0.2"
+            "yargs": "^13.3.0"
           }
         }
       }
     },
     "jest-changed-files": {
-      "version": "24.8.0",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/jest-changed-files/-/jest-changed-files-24.8.0.tgz",
-      "integrity": "sha1-fn6yHPaHWHqF5Q89JJ0TJ+FbFXs=",
+      "version": "24.9.0",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/jest-changed-files/-/jest-changed-files-24.9.0.tgz",
+      "integrity": "sha1-CNjBXreaf6P8mCabwUtFHugvgDk=",
       "dev": true,
       "requires": {
-        "@jest/types": "^24.8.0",
+        "@jest/types": "^24.9.0",
         "execa": "^1.0.0",
         "throat": "^4.0.0"
       }
     },
     "jest-config": {
-      "version": "24.8.0",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/jest-config/-/jest-config-24.8.0.tgz",
-      "integrity": "sha1-d9s9JlpvcmKUaHy7zMNvinbuD08=",
+      "version": "24.9.0",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/jest-config/-/jest-config-24.9.0.tgz",
+      "integrity": "sha1-+xu8YMc6Rq8DWQcZ76SCXm5N0bU=",
       "dev": true,
       "requires": {
         "@babel/core": "^7.1.0",
-        "@jest/test-sequencer": "^24.8.0",
-        "@jest/types": "^24.8.0",
-        "babel-jest": "^24.8.0",
+        "@jest/test-sequencer": "^24.9.0",
+        "@jest/types": "^24.9.0",
+        "babel-jest": "^24.9.0",
         "chalk": "^2.0.1",
         "glob": "^7.1.1",
-        "jest-environment-jsdom": "^24.8.0",
-        "jest-environment-node": "^24.8.0",
-        "jest-get-type": "^24.8.0",
-        "jest-jasmine2": "^24.8.0",
+        "jest-environment-jsdom": "^24.9.0",
+        "jest-environment-node": "^24.9.0",
+        "jest-get-type": "^24.9.0",
+        "jest-jasmine2": "^24.9.0",
         "jest-regex-util": "^24.3.0",
-        "jest-resolve": "^24.8.0",
-        "jest-util": "^24.8.0",
-        "jest-validate": "^24.8.0",
+        "jest-resolve": "^24.9.0",
+        "jest-util": "^24.9.0",
+        "jest-validate": "^24.9.0",
         "micromatch": "^3.1.10",
-        "pretty-format": "^24.8.0",
+        "pretty-format": "^24.9.0",
         "realpath-native": "^1.1.0"
       }
     },
     "jest-diff": {
-      "version": "24.8.0",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/jest-diff/-/jest-diff-24.8.0.tgz",
-      "integrity": "sha1-FGQ159Hj/98pPVP/l+GT8dFUYXI=",
+      "version": "24.9.0",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/jest-diff/-/jest-diff-24.9.0.tgz",
+      "integrity": "sha1-kxt9DVd4obr3RSy4FuMl43JAVdo=",
       "dev": true,
       "requires": {
         "chalk": "^2.0.1",
-        "diff-sequences": "^24.3.0",
-        "jest-get-type": "^24.8.0",
-        "pretty-format": "^24.8.0"
+        "diff-sequences": "^24.9.0",
+        "jest-get-type": "^24.9.0",
+        "pretty-format": "^24.9.0"
       }
     },
     "jest-docblock": {
-      "version": "24.3.0",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/jest-docblock/-/jest-docblock-24.3.0.tgz",
-      "integrity": "sha1-ucMtrHD3LkRkUg0rpK7AKrFNtd0=",
+      "version": "24.9.0",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/jest-docblock/-/jest-docblock-24.9.0.tgz",
+      "integrity": "sha1-eXAgGAK6Vg4cQJLMJcvt9a9ajOI=",
       "dev": true,
       "requires": {
         "detect-newline": "^2.1.0"
       }
     },
     "jest-each": {
-      "version": "24.8.0",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/jest-each/-/jest-each-24.8.0.tgz",
-      "integrity": "sha1-oF/Sv5TdwLHaZsbRPsJFfzXlJ3U=",
+      "version": "24.9.0",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/jest-each/-/jest-each-24.9.0.tgz",
+      "integrity": "sha1-6y2mAuKmEImNvF8fbfO6hrVfiwU=",
       "dev": true,
       "requires": {
-        "@jest/types": "^24.8.0",
+        "@jest/types": "^24.9.0",
         "chalk": "^2.0.1",
-        "jest-get-type": "^24.8.0",
-        "jest-util": "^24.8.0",
-        "pretty-format": "^24.8.0"
+        "jest-get-type": "^24.9.0",
+        "jest-util": "^24.9.0",
+        "pretty-format": "^24.9.0"
       }
     },
     "jest-environment-jsdom": {
-      "version": "24.8.0",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/jest-environment-jsdom/-/jest-environment-jsdom-24.8.0.tgz",
-      "integrity": "sha1-MA9pSaFGyr4ck1etnp7Pn0PziFc=",
+      "version": "24.9.0",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/jest-environment-jsdom/-/jest-environment-jsdom-24.9.0.tgz",
+      "integrity": "sha1-SwgGx/yU+V7bNpppzCd47sK3N1s=",
       "dev": true,
       "requires": {
-        "@jest/environment": "^24.8.0",
-        "@jest/fake-timers": "^24.8.0",
-        "@jest/types": "^24.8.0",
-        "jest-mock": "^24.8.0",
-        "jest-util": "^24.8.0",
+        "@jest/environment": "^24.9.0",
+        "@jest/fake-timers": "^24.9.0",
+        "@jest/types": "^24.9.0",
+        "jest-mock": "^24.9.0",
+        "jest-util": "^24.9.0",
         "jsdom": "^11.5.1"
       }
     },
     "jest-environment-node": {
-      "version": "24.8.0",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/jest-environment-node/-/jest-environment-node-24.8.0.tgz",
-      "integrity": "sha1-0/cmuovFMIemDnqEygiIOkyJIjE=",
+      "version": "24.9.0",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/jest-environment-node/-/jest-environment-node-24.9.0.tgz",
+      "integrity": "sha1-Mz0tJ5b5aH8q7r8HQrUZ8zwcv9M=",
       "dev": true,
       "requires": {
-        "@jest/environment": "^24.8.0",
-        "@jest/fake-timers": "^24.8.0",
-        "@jest/types": "^24.8.0",
-        "jest-mock": "^24.8.0",
-        "jest-util": "^24.8.0"
+        "@jest/environment": "^24.9.0",
+        "@jest/fake-timers": "^24.9.0",
+        "@jest/types": "^24.9.0",
+        "jest-mock": "^24.9.0",
+        "jest-util": "^24.9.0"
       }
     },
     "jest-get-type": {
-      "version": "24.8.0",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/jest-get-type/-/jest-get-type-24.8.0.tgz",
-      "integrity": "sha1-p0QN4wtlH1pw6j7X/wc6Mt/mRvw=",
+      "version": "24.9.0",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/jest-get-type/-/jest-get-type-24.9.0.tgz",
+      "integrity": "sha1-FoSgyKUPLkkBtmRK6GH1ee7S7w4=",
       "dev": true
     },
     "jest-haste-map": {
-      "version": "24.8.1",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/jest-haste-map/-/jest-haste-map-24.8.1.tgz",
-      "integrity": "sha1-85zB0rHZB+AUFltL1alXr8uZKYI=",
+      "version": "24.9.0",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/jest-haste-map/-/jest-haste-map-24.9.0.tgz",
+      "integrity": "sha1-s4pdZCdJNOIfpBeump++t3zqrH0=",
       "dev": true,
       "requires": {
-        "@jest/types": "^24.8.0",
+        "@jest/types": "^24.9.0",
         "anymatch": "^2.0.0",
         "fb-watchman": "^2.0.0",
         "fsevents": "^1.2.7",
         "graceful-fs": "^4.1.15",
         "invariant": "^2.2.4",
-        "jest-serializer": "^24.4.0",
-        "jest-util": "^24.8.0",
-        "jest-worker": "^24.6.0",
+        "jest-serializer": "^24.9.0",
+        "jest-util": "^24.9.0",
+        "jest-worker": "^24.9.0",
         "micromatch": "^3.1.10",
         "sane": "^4.0.3",
         "walker": "^1.0.7"
       }
     },
     "jest-jasmine2": {
-      "version": "24.8.0",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/jest-jasmine2/-/jest-jasmine2-24.8.0.tgz",
-      "integrity": "sha1-qcfhTIPdd9ixXoIFSc6Jh8yM2Jg=",
+      "version": "24.9.0",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/jest-jasmine2/-/jest-jasmine2-24.9.0.tgz",
+      "integrity": "sha1-H3sb0yQsF3TmKsq7NkbZavw75qA=",
       "dev": true,
       "requires": {
         "@babel/traverse": "^7.1.0",
-        "@jest/environment": "^24.8.0",
-        "@jest/test-result": "^24.8.0",
-        "@jest/types": "^24.8.0",
+        "@jest/environment": "^24.9.0",
+        "@jest/test-result": "^24.9.0",
+        "@jest/types": "^24.9.0",
         "chalk": "^2.0.1",
         "co": "^4.6.0",
-        "expect": "^24.8.0",
+        "expect": "^24.9.0",
         "is-generator-fn": "^2.0.0",
-        "jest-each": "^24.8.0",
-        "jest-matcher-utils": "^24.8.0",
-        "jest-message-util": "^24.8.0",
-        "jest-runtime": "^24.8.0",
-        "jest-snapshot": "^24.8.0",
-        "jest-util": "^24.8.0",
-        "pretty-format": "^24.8.0",
+        "jest-each": "^24.9.0",
+        "jest-matcher-utils": "^24.9.0",
+        "jest-message-util": "^24.9.0",
+        "jest-runtime": "^24.9.0",
+        "jest-snapshot": "^24.9.0",
+        "jest-util": "^24.9.0",
+        "pretty-format": "^24.9.0",
         "throat": "^4.0.0"
-      },
-      "dependencies": {
-        "@babel/code-frame": {
-          "version": "7.0.0",
-          "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/@babel/code-frame/-/code-frame-7.0.0.tgz",
-          "integrity": "sha1-BuKrGb21NThVWaq7W6WXKUgoAPg=",
-          "dev": true,
-          "requires": {
-            "@babel/highlight": "^7.0.0"
-          }
-        },
-        "@babel/generator": {
-          "version": "7.4.4",
-          "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/@babel/generator/-/generator-7.4.4.tgz",
-          "integrity": "sha1-F0ohXrhD/DksftyqvqqHPebo8EE=",
-          "dev": true,
-          "requires": {
-            "@babel/types": "^7.4.4",
-            "jsesc": "^2.5.1",
-            "lodash": "^4.17.11",
-            "source-map": "^0.5.0",
-            "trim-right": "^1.0.1"
-          }
-        },
-        "@babel/helper-function-name": {
-          "version": "7.1.0",
-          "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
-          "integrity": "sha1-oM6wFoX3M1XUNgwSR/WCv6/I/1M=",
-          "dev": true,
-          "requires": {
-            "@babel/helper-get-function-arity": "^7.0.0",
-            "@babel/template": "^7.1.0",
-            "@babel/types": "^7.0.0"
-          }
-        },
-        "@babel/helper-get-function-arity": {
-          "version": "7.0.0",
-          "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
-          "integrity": "sha1-g1ctQyDipGVyY3NBE8QoaLZOScM=",
-          "dev": true,
-          "requires": {
-            "@babel/types": "^7.0.0"
-          }
-        },
-        "@babel/helper-split-export-declaration": {
-          "version": "7.4.4",
-          "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
-          "integrity": "sha1-/5SJSjQL549T8GrwOLIFxJ2ZNnc=",
-          "dev": true,
-          "requires": {
-            "@babel/types": "^7.4.4"
-          }
-        },
-        "@babel/highlight": {
-          "version": "7.0.0",
-          "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/@babel/highlight/-/highlight-7.0.0.tgz",
-          "integrity": "sha1-9xDDjI1Fjm3ZogGvtjf8t4HOmeQ=",
-          "dev": true,
-          "requires": {
-            "chalk": "^2.0.0",
-            "esutils": "^2.0.2",
-            "js-tokens": "^4.0.0"
-          }
-        },
-        "@babel/template": {
-          "version": "7.4.4",
-          "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/@babel/template/-/template-7.4.4.tgz",
-          "integrity": "sha1-9LiNEiVomgj1vDoXSDVFvp5O0jc=",
-          "dev": true,
-          "requires": {
-            "@babel/code-frame": "^7.0.0",
-            "@babel/parser": "^7.4.4",
-            "@babel/types": "^7.4.4"
-          }
-        },
-        "@babel/traverse": {
-          "version": "7.4.5",
-          "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/@babel/traverse/-/traverse-7.4.5.tgz",
-          "integrity": "sha1-TpLRco/S8Yl9r90yHvv/khVsMhY=",
-          "dev": true,
-          "requires": {
-            "@babel/code-frame": "^7.0.0",
-            "@babel/generator": "^7.4.4",
-            "@babel/helper-function-name": "^7.1.0",
-            "@babel/helper-split-export-declaration": "^7.4.4",
-            "@babel/parser": "^7.4.5",
-            "@babel/types": "^7.4.4",
-            "debug": "^4.1.0",
-            "globals": "^11.1.0",
-            "lodash": "^4.17.11"
-          }
-        },
-        "@babel/types": {
-          "version": "7.4.4",
-          "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/@babel/types/-/types-7.4.4.tgz",
-          "integrity": "sha1-jbnppim7fCk3AAm0t3ntk/5X1fA=",
-          "dev": true,
-          "requires": {
-            "esutils": "^2.0.2",
-            "lodash": "^4.17.11",
-            "to-fast-properties": "^2.0.0"
-          }
-        },
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "js-tokens": {
-          "version": "4.0.0",
-          "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/js-tokens/-/js-tokens-4.0.0.tgz",
-          "integrity": "sha1-GSA/tZmR35jjoocFDUZHzerzJJk=",
-          "dev": true
-        }
       }
     },
     "jest-leak-detector": {
-      "version": "24.8.0",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/jest-leak-detector/-/jest-leak-detector-24.8.0.tgz",
-      "integrity": "sha1-wAhjhOH2UMLYNICV33afKbSOaYA=",
+      "version": "24.9.0",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/jest-leak-detector/-/jest-leak-detector-24.9.0.tgz",
+      "integrity": "sha1-tmXep8dxAMXE99/LFTtlzwfc+Wo=",
       "dev": true,
       "requires": {
-        "pretty-format": "^24.8.0"
+        "jest-get-type": "^24.9.0",
+        "pretty-format": "^24.9.0"
       }
     },
     "jest-matcher-utils": {
-      "version": "24.8.0",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/jest-matcher-utils/-/jest-matcher-utils-24.8.0.tgz",
-      "integrity": "sha1-K85CIEya8SveRvg9yDnv6L6DJJU=",
+      "version": "24.9.0",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/jest-matcher-utils/-/jest-matcher-utils-24.9.0.tgz",
+      "integrity": "sha1-9bNmHV5ijf/m3WUlHf2uDofDoHM=",
       "dev": true,
       "requires": {
         "chalk": "^2.0.1",
-        "jest-diff": "^24.8.0",
-        "jest-get-type": "^24.8.0",
-        "pretty-format": "^24.8.0"
+        "jest-diff": "^24.9.0",
+        "jest-get-type": "^24.9.0",
+        "pretty-format": "^24.9.0"
       }
     },
     "jest-message-util": {
-      "version": "24.8.0",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/jest-message-util/-/jest-message-util-24.8.0.tgz",
-      "integrity": "sha1-DWiR5ypL6swCkrY4aF30LijWIYs=",
+      "version": "24.9.0",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/jest-message-util/-/jest-message-util-24.9.0.tgz",
+      "integrity": "sha1-Un9UoeOA9eICqNEUmw7IcvQxGeM=",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
-        "@jest/test-result": "^24.8.0",
-        "@jest/types": "^24.8.0",
+        "@jest/test-result": "^24.9.0",
+        "@jest/types": "^24.9.0",
         "@types/stack-utils": "^1.0.1",
         "chalk": "^2.0.1",
         "micromatch": "^3.1.10",
         "slash": "^2.0.0",
         "stack-utils": "^1.0.1"
-      },
-      "dependencies": {
-        "@babel/code-frame": {
-          "version": "7.0.0",
-          "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/@babel/code-frame/-/code-frame-7.0.0.tgz",
-          "integrity": "sha1-BuKrGb21NThVWaq7W6WXKUgoAPg=",
-          "dev": true,
-          "requires": {
-            "@babel/highlight": "^7.0.0"
-          }
-        },
-        "@babel/highlight": {
-          "version": "7.0.0",
-          "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/@babel/highlight/-/highlight-7.0.0.tgz",
-          "integrity": "sha1-9xDDjI1Fjm3ZogGvtjf8t4HOmeQ=",
-          "dev": true,
-          "requires": {
-            "chalk": "^2.0.0",
-            "esutils": "^2.0.2",
-            "js-tokens": "^4.0.0"
-          }
-        },
-        "js-tokens": {
-          "version": "4.0.0",
-          "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/js-tokens/-/js-tokens-4.0.0.tgz",
-          "integrity": "sha1-GSA/tZmR35jjoocFDUZHzerzJJk=",
-          "dev": true
-        }
       }
     },
     "jest-mock": {
-      "version": "24.8.0",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/jest-mock/-/jest-mock-24.8.0.tgz",
-      "integrity": "sha1-L50U03aZ6GPx/r9OTVozt/273lY=",
+      "version": "24.9.0",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/jest-mock/-/jest-mock-24.9.0.tgz",
+      "integrity": "sha1-wig1VB7jebkIZzrVEIeiGFwT8cY=",
       "dev": true,
       "requires": {
-        "@jest/types": "^24.8.0"
+        "@jest/types": "^24.9.0"
       }
     },
     "jest-pnp-resolver": {
-      "version": "1.2.1",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/jest-pnp-resolver/-/jest-pnp-resolver-1.2.1.tgz",
-      "integrity": "sha1-7NrmBMB3p/vHDe+21RfDwciYkjo=",
+      "version": "1.2.2",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
+      "integrity": "sha1-twSsCuAoqJEIpNBAs/kZ393I4zw=",
       "dev": true
     },
     "jest-regex-util": {
-      "version": "24.3.0",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/jest-regex-util/-/jest-regex-util-24.3.0.tgz",
-      "integrity": "sha1-1aZfYL4a4+MQ1SFKAwdYGZUiezY=",
+      "version": "24.9.0",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/jest-regex-util/-/jest-regex-util-24.9.0.tgz",
+      "integrity": "sha1-wT+zOAveIr9ldUMsST6o/jeWVjY=",
       "dev": true
     },
     "jest-resolve": {
-      "version": "24.8.0",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/jest-resolve/-/jest-resolve-24.8.0.tgz",
-      "integrity": "sha1-hLjlQIwfahFTl5Pitf6xtuciQ58=",
+      "version": "24.9.0",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/jest-resolve/-/jest-resolve-24.9.0.tgz",
+      "integrity": "sha1-3/BMdoevNMTdflJIktnPd+XRcyE=",
       "dev": true,
       "requires": {
-        "@jest/types": "^24.8.0",
+        "@jest/types": "^24.9.0",
         "browser-resolve": "^1.11.3",
         "chalk": "^2.0.1",
         "jest-pnp-resolver": "^1.2.1",
@@ -3912,124 +3187,120 @@
       }
     },
     "jest-resolve-dependencies": {
-      "version": "24.8.0",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/jest-resolve-dependencies/-/jest-resolve-dependencies-24.8.0.tgz",
-      "integrity": "sha1-Ge7DJB8gRdP5kNujMdDXUmrP+OA=",
+      "version": "24.9.0",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/jest-resolve-dependencies/-/jest-resolve-dependencies-24.9.0.tgz",
+      "integrity": "sha1-rQVRmJWcTPuopPBmxnOj8HhlB6s=",
       "dev": true,
       "requires": {
-        "@jest/types": "^24.8.0",
+        "@jest/types": "^24.9.0",
         "jest-regex-util": "^24.3.0",
-        "jest-snapshot": "^24.8.0"
+        "jest-snapshot": "^24.9.0"
       }
     },
     "jest-runner": {
-      "version": "24.8.0",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/jest-runner/-/jest-runner-24.8.0.tgz",
-      "integrity": "sha1-T5rge3Z9snt0DX3v+tDPZ8y0xbs=",
+      "version": "24.9.0",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/jest-runner/-/jest-runner-24.9.0.tgz",
+      "integrity": "sha1-V0+v29VEVcKzS0vfQ2WiOFf830I=",
       "dev": true,
       "requires": {
         "@jest/console": "^24.7.1",
-        "@jest/environment": "^24.8.0",
-        "@jest/test-result": "^24.8.0",
-        "@jest/types": "^24.8.0",
+        "@jest/environment": "^24.9.0",
+        "@jest/test-result": "^24.9.0",
+        "@jest/types": "^24.9.0",
         "chalk": "^2.4.2",
         "exit": "^0.1.2",
         "graceful-fs": "^4.1.15",
-        "jest-config": "^24.8.0",
+        "jest-config": "^24.9.0",
         "jest-docblock": "^24.3.0",
-        "jest-haste-map": "^24.8.0",
-        "jest-jasmine2": "^24.8.0",
-        "jest-leak-detector": "^24.8.0",
-        "jest-message-util": "^24.8.0",
-        "jest-resolve": "^24.8.0",
-        "jest-runtime": "^24.8.0",
-        "jest-util": "^24.8.0",
+        "jest-haste-map": "^24.9.0",
+        "jest-jasmine2": "^24.9.0",
+        "jest-leak-detector": "^24.9.0",
+        "jest-message-util": "^24.9.0",
+        "jest-resolve": "^24.9.0",
+        "jest-runtime": "^24.9.0",
+        "jest-util": "^24.9.0",
         "jest-worker": "^24.6.0",
         "source-map-support": "^0.5.6",
         "throat": "^4.0.0"
       }
     },
     "jest-runtime": {
-      "version": "24.8.0",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/jest-runtime/-/jest-runtime-24.8.0.tgz",
-      "integrity": "sha1-BflNWwXCH23FTkJ80uSYCSM1BiA=",
+      "version": "24.9.0",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/jest-runtime/-/jest-runtime-24.9.0.tgz",
+      "integrity": "sha1-nxRYOvak9zFKap2fAibhp4HI5Kw=",
       "dev": true,
       "requires": {
         "@jest/console": "^24.7.1",
-        "@jest/environment": "^24.8.0",
+        "@jest/environment": "^24.9.0",
         "@jest/source-map": "^24.3.0",
-        "@jest/transform": "^24.8.0",
-        "@jest/types": "^24.8.0",
-        "@types/yargs": "^12.0.2",
+        "@jest/transform": "^24.9.0",
+        "@jest/types": "^24.9.0",
+        "@types/yargs": "^13.0.0",
         "chalk": "^2.0.1",
         "exit": "^0.1.2",
         "glob": "^7.1.3",
         "graceful-fs": "^4.1.15",
-        "jest-config": "^24.8.0",
-        "jest-haste-map": "^24.8.0",
-        "jest-message-util": "^24.8.0",
-        "jest-mock": "^24.8.0",
+        "jest-config": "^24.9.0",
+        "jest-haste-map": "^24.9.0",
+        "jest-message-util": "^24.9.0",
+        "jest-mock": "^24.9.0",
         "jest-regex-util": "^24.3.0",
-        "jest-resolve": "^24.8.0",
-        "jest-snapshot": "^24.8.0",
-        "jest-util": "^24.8.0",
-        "jest-validate": "^24.8.0",
+        "jest-resolve": "^24.9.0",
+        "jest-snapshot": "^24.9.0",
+        "jest-util": "^24.9.0",
+        "jest-validate": "^24.9.0",
         "realpath-native": "^1.1.0",
         "slash": "^2.0.0",
         "strip-bom": "^3.0.0",
-        "yargs": "^12.0.2"
+        "yargs": "^13.3.0"
       }
     },
     "jest-serializer": {
-      "version": "24.4.0",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/jest-serializer/-/jest-serializer-24.4.0.tgz",
-      "integrity": "sha1-9wxZGMjqkjXMsSdtIy5FkIBYjbM=",
+      "version": "24.9.0",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/jest-serializer/-/jest-serializer-24.9.0.tgz",
+      "integrity": "sha1-5tfX75bTHouQeacUdUxdXFgojnM=",
       "dev": true
     },
     "jest-snapshot": {
-      "version": "24.8.0",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/jest-snapshot/-/jest-snapshot-24.8.0.tgz",
-      "integrity": "sha1-O+xqWdov97x9CXqFP7Z/nUFct8Y=",
+      "version": "24.9.0",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/jest-snapshot/-/jest-snapshot-24.9.0.tgz",
+      "integrity": "sha1-7I6cpPLsDFyHro+SXPl0l7DpUbo=",
       "dev": true,
       "requires": {
         "@babel/types": "^7.0.0",
-        "@jest/types": "^24.8.0",
+        "@jest/types": "^24.9.0",
         "chalk": "^2.0.1",
-        "expect": "^24.8.0",
-        "jest-diff": "^24.8.0",
-        "jest-matcher-utils": "^24.8.0",
-        "jest-message-util": "^24.8.0",
-        "jest-resolve": "^24.8.0",
+        "expect": "^24.9.0",
+        "jest-diff": "^24.9.0",
+        "jest-get-type": "^24.9.0",
+        "jest-matcher-utils": "^24.9.0",
+        "jest-message-util": "^24.9.0",
+        "jest-resolve": "^24.9.0",
         "mkdirp": "^0.5.1",
         "natural-compare": "^1.4.0",
-        "pretty-format": "^24.8.0",
-        "semver": "^5.5.0"
+        "pretty-format": "^24.9.0",
+        "semver": "^6.2.0"
       },
       "dependencies": {
-        "@babel/types": {
-          "version": "7.4.4",
-          "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/@babel/types/-/types-7.4.4.tgz",
-          "integrity": "sha1-jbnppim7fCk3AAm0t3ntk/5X1fA=",
-          "dev": true,
-          "requires": {
-            "esutils": "^2.0.2",
-            "lodash": "^4.17.11",
-            "to-fast-properties": "^2.0.0"
-          }
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha1-7gpkyK9ejO6mdoexM3YeG+y9HT0=",
+          "dev": true
         }
       }
     },
     "jest-util": {
-      "version": "24.8.0",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/jest-util/-/jest-util-24.8.0.tgz",
-      "integrity": "sha1-QfDpRdoR30TMdtZP+5FdBxb0bNE=",
+      "version": "24.9.0",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/jest-util/-/jest-util-24.9.0.tgz",
+      "integrity": "sha1-c5aBTkhTbS6Fo33j5MQx18sUAWI=",
       "dev": true,
       "requires": {
-        "@jest/console": "^24.7.1",
-        "@jest/fake-timers": "^24.8.0",
-        "@jest/source-map": "^24.3.0",
-        "@jest/test-result": "^24.8.0",
-        "@jest/types": "^24.8.0",
+        "@jest/console": "^24.9.0",
+        "@jest/fake-timers": "^24.9.0",
+        "@jest/source-map": "^24.9.0",
+        "@jest/test-result": "^24.9.0",
+        "@jest/types": "^24.9.0",
         "callsites": "^3.0.0",
         "chalk": "^2.0.1",
         "graceful-fs": "^4.1.15",
@@ -4037,52 +3308,44 @@
         "mkdirp": "^0.5.1",
         "slash": "^2.0.0",
         "source-map": "^0.6.0"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
-          "dev": true
-        }
       }
     },
     "jest-validate": {
-      "version": "24.8.0",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/jest-validate/-/jest-validate-24.8.0.tgz",
-      "integrity": "sha1-YkxBUz5t/jVv+txuJCOjXC07SEk=",
+      "version": "24.9.0",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/jest-validate/-/jest-validate-24.9.0.tgz",
+      "integrity": "sha1-B3XFU2DRc82FTkAYB1bU/1Le+Ks=",
       "dev": true,
       "requires": {
-        "@jest/types": "^24.8.0",
-        "camelcase": "^5.0.0",
+        "@jest/types": "^24.9.0",
+        "camelcase": "^5.3.1",
         "chalk": "^2.0.1",
-        "jest-get-type": "^24.8.0",
-        "leven": "^2.1.0",
-        "pretty-format": "^24.8.0"
+        "jest-get-type": "^24.9.0",
+        "leven": "^3.1.0",
+        "pretty-format": "^24.9.0"
       }
     },
     "jest-watcher": {
-      "version": "24.8.0",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/jest-watcher/-/jest-watcher-24.8.0.tgz",
-      "integrity": "sha1-WNSZFc7d0t6F4jj2ITzvHJNxXeQ=",
+      "version": "24.9.0",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/jest-watcher/-/jest-watcher-24.9.0.tgz",
+      "integrity": "sha1-S1bl0c7/AF9biOUo3Jr8jdTtKzs=",
       "dev": true,
       "requires": {
-        "@jest/test-result": "^24.8.0",
-        "@jest/types": "^24.8.0",
-        "@types/yargs": "^12.0.9",
+        "@jest/test-result": "^24.9.0",
+        "@jest/types": "^24.9.0",
+        "@types/yargs": "^13.0.0",
         "ansi-escapes": "^3.0.0",
         "chalk": "^2.0.1",
-        "jest-util": "^24.8.0",
+        "jest-util": "^24.9.0",
         "string-length": "^2.0.0"
       }
     },
     "jest-worker": {
-      "version": "24.6.0",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/jest-worker/-/jest-worker-24.6.0.tgz",
-      "integrity": "sha1-f4HOrjS3zeDJgnppgMNbfNwBYbM=",
+      "version": "24.9.0",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/jest-worker/-/jest-worker-24.9.0.tgz",
+      "integrity": "sha1-Xb/bWy0yLphWeJgjipaXvM5ns+U=",
       "dev": true,
       "requires": {
-        "merge-stream": "^1.0.1",
+        "merge-stream": "^2.0.0",
         "supports-color": "^6.1.0"
       },
       "dependencies": {
@@ -4098,9 +3361,9 @@
       }
     },
     "js-tokens": {
-      "version": "3.0.2",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/js-tokens/-/js-tokens-3.0.2.tgz",
-      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+      "version": "4.0.0",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha1-GSA/tZmR35jjoocFDUZHzerzJJk=",
       "dev": true
     },
     "js-yaml": {
@@ -4154,9 +3417,9 @@
       },
       "dependencies": {
         "acorn": {
-          "version": "5.7.3",
-          "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/acorn/-/acorn-5.7.3.tgz",
-          "integrity": "sha1-Z6ojG/iBKXS4UjWpZ3Hra9B+onk=",
+          "version": "5.7.4",
+          "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/acorn/-/acorn-5.7.4.tgz",
+          "integrity": "sha1-Po2KmUfQWZoXltECJddDL0pKz14=",
           "dev": true
         }
       }
@@ -4197,20 +3460,12 @@
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
     },
     "json5": {
-      "version": "2.1.0",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/json5/-/json5-2.1.0.tgz",
-      "integrity": "sha1-56DGLEgoXGKNIKELhcibuAfDKFA=",
+      "version": "1.0.1",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/json5/-/json5-1.0.1.tgz",
+      "integrity": "sha1-d5+wAYYE+oVOrL9iUhgNg1Q+Pb4=",
       "dev": true,
       "requires": {
         "minimist": "^1.2.0"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-          "dev": true
-        }
       }
     },
     "jsprim": {
@@ -4226,9 +3481,9 @@
       }
     },
     "kind-of": {
-      "version": "6.0.2",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/kind-of/-/kind-of-6.0.2.tgz",
-      "integrity": "sha1-ARRrNqYhjmTljzqNZt5df8b20FE=",
+      "version": "6.0.3",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha1-B8BQNKbDSfoG4k+jWqdttFgM5N0=",
       "dev": true
     },
     "kleur": {
@@ -4237,15 +3492,6 @@
       "integrity": "sha1-p5yezIbuHOP6YgbRIWxQHxR/wH4=",
       "dev": true
     },
-    "lcid": {
-      "version": "2.0.0",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/lcid/-/lcid-2.0.0.tgz",
-      "integrity": "sha1-bvXS32DlL4LrIopMNz6NHzlyU88=",
-      "dev": true,
-      "requires": {
-        "invert-kv": "^2.0.0"
-      }
-    },
     "left-pad": {
       "version": "1.3.0",
       "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/left-pad/-/left-pad-1.3.0.tgz",
@@ -4253,9 +3499,9 @@
       "dev": true
     },
     "leven": {
-      "version": "2.1.0",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/leven/-/leven-2.1.0.tgz",
-      "integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA=",
+      "version": "3.1.0",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/leven/-/leven-3.1.0.tgz",
+      "integrity": "sha1-d4kd6DQGTMy6gq54QrtrFKE+1/I=",
       "dev": true
     },
     "levn": {
@@ -4291,9 +3537,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.11",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha1-s56mIp72B+zYniyN8SU2iRysm40="
+      "version": "4.17.21",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha1-Z5WRxWTDv/quhFTPCz3zcMPWkRw="
     },
     "lodash.sortby": {
       "version": "4.7.0",
@@ -4337,15 +3583,6 @@
         "tmpl": "1.0.x"
       }
     },
-    "map-age-cleaner": {
-      "version": "0.1.3",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
-      "integrity": "sha1-fVg6cwZDTAVf5HSw9FB45uG0uSo=",
-      "dev": true,
-      "requires": {
-        "p-defer": "^1.0.0"
-      }
-    },
     "map-cache": {
       "version": "0.2.2",
       "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/map-cache/-/map-cache-0.2.2.tgz",
@@ -4361,33 +3598,11 @@
         "object-visit": "^1.0.0"
       }
     },
-    "mem": {
-      "version": "4.3.0",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/mem/-/mem-4.3.0.tgz",
-      "integrity": "sha1-Rhr0l7xK4JYIzbLmDu+2m/90QXg=",
-      "dev": true,
-      "requires": {
-        "map-age-cleaner": "^0.1.1",
-        "mimic-fn": "^2.0.0",
-        "p-is-promise": "^2.0.0"
-      },
-      "dependencies": {
-        "mimic-fn": {
-          "version": "2.1.0",
-          "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/mimic-fn/-/mimic-fn-2.1.0.tgz",
-          "integrity": "sha1-ftLCzMyvhNP/y3pptXcR/CCDQBs=",
-          "dev": true
-        }
-      }
-    },
     "merge-stream": {
-      "version": "1.0.1",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/merge-stream/-/merge-stream-1.0.1.tgz",
-      "integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
-      "dev": true,
-      "requires": {
-        "readable-stream": "^2.0.1"
-      }
+      "version": "2.0.0",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha1-UoI2KaFN0AyXcPtq1H3GMQ8sH2A=",
+      "dev": true
     },
     "micromatch": {
       "version": "3.1.10",
@@ -4411,18 +3626,18 @@
       }
     },
     "mime-db": {
-      "version": "1.40.0",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/mime-db/-/mime-db-1.40.0.tgz",
-      "integrity": "sha1-plBX6ZjbCQ9zKmj2wnbTh9QSbDI=",
+      "version": "1.46.0",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/mime-db/-/mime-db-1.46.0.tgz",
+      "integrity": "sha1-Ymd0in95lZTePLyM3pHe80lmHO4=",
       "dev": true
     },
     "mime-types": {
-      "version": "2.1.24",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/mime-types/-/mime-types-2.1.24.tgz",
-      "integrity": "sha1-tvjQs+lR77d97eyhlM/20W9nb4E=",
+      "version": "2.1.29",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/mime-types/-/mime-types-2.1.29.tgz",
+      "integrity": "sha1-HUq3faZLkfX3JInfKSNlY3VLsbI=",
       "dev": true,
       "requires": {
-        "mime-db": "1.40.0"
+        "mime-db": "1.46.0"
       }
     },
     "mimic-fn": {
@@ -4441,14 +3656,14 @@
       }
     },
     "minimist": {
-      "version": "0.0.8",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+      "version": "1.2.5",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha1-Z9ZgFLZqaoqqDAg8X9WN9OTpdgI="
     },
     "mixin-deep": {
-      "version": "1.3.1",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/mixin-deep/-/mixin-deep-1.3.1.tgz",
-      "integrity": "sha1-pJ5yaNzhoNlpjkUybFYm3zVD0P4=",
+      "version": "1.3.2",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/mixin-deep/-/mixin-deep-1.3.2.tgz",
+      "integrity": "sha1-ESC0PcNZp4Xc5ltVuC4lfM9HlWY=",
       "dev": true,
       "requires": {
         "for-in": "^1.0.2",
@@ -4467,11 +3682,11 @@
       }
     },
     "mkdirp": {
-      "version": "0.5.1",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/mkdirp/-/mkdirp-0.5.1.tgz",
-      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "version": "0.5.5",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/mkdirp/-/mkdirp-0.5.5.tgz",
+      "integrity": "sha1-2Rzv1i0UNsoPQWIOJRKI1CAJne8=",
       "requires": {
-        "minimist": "0.0.8"
+        "minimist": "^1.2.5"
       }
     },
     "ms": {
@@ -4486,9 +3701,9 @@
       "dev": true
     },
     "nan": {
-      "version": "2.14.0",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/nan/-/nan-2.14.0.tgz",
-      "integrity": "sha1-eBj3IgJ7JFmobwKV1DTR/CM2xSw=",
+      "version": "2.14.2",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/nan/-/nan-2.14.2.tgz",
+      "integrity": "sha1-9TdkAGlRaPTMaUrJOT0MlYXu6hk=",
       "dev": true,
       "optional": true
     },
@@ -4515,12 +3730,6 @@
       "version": "1.4.0",
       "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
-      "dev": true
-    },
-    "neo-async": {
-      "version": "2.6.1",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/neo-async/-/neo-async-2.6.1.tgz",
-      "integrity": "sha1-rCetpmFn+ohJpq3dg39rGJrSCBw=",
       "dev": true
     },
     "nice-try": {
@@ -4556,9 +3765,9 @@
       }
     },
     "node-fetch": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
-      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==",
+      "version": "2.6.1",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha1-BFvTI2Mfdu0uK1VXM5RBa2OaAFI=",
       "dev": true
     },
     "node-int64": {
@@ -4574,9 +3783,9 @@
       "dev": true
     },
     "node-notifier": {
-      "version": "5.4.0",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/node-notifier/-/node-notifier-5.4.0.tgz",
-      "integrity": "sha1-e0Vf3On33gxjU4KXNU89tGhCbmo=",
+      "version": "5.4.5",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/node-notifier/-/node-notifier-5.4.5.tgz",
+      "integrity": "sha1-DLwaKw9lhJO0Ald1oTrZOOlgke8=",
       "dev": true,
       "requires": {
         "growly": "^1.3.0",
@@ -4585,6 +3794,12 @@
         "shellwords": "^0.1.1",
         "which": "^1.3.0"
       }
+    },
+    "node-releases": {
+      "version": "1.1.71",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/node-releases/-/node-releases-1.1.71.tgz",
+      "integrity": "sha1-yxM0sXmJaxyJ7P3UtyX7e738fbs=",
+      "dev": true
     },
     "normalize-package-data": {
       "version": "2.5.0",
@@ -4598,6 +3813,15 @@
         "validate-npm-package-license": "^3.0.1"
       }
     },
+    "normalize-path": {
+      "version": "2.1.1",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/normalize-path/-/normalize-path-2.1.1.tgz",
+      "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+      "dev": true,
+      "requires": {
+        "remove-trailing-separator": "^1.0.1"
+      }
+    },
     "npm-run-path": {
       "version": "2.0.2",
       "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/npm-run-path/-/npm-run-path-2.0.2.tgz",
@@ -4607,16 +3831,10 @@
         "path-key": "^2.0.0"
       }
     },
-    "number-is-nan": {
-      "version": "1.0.1",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/number-is-nan/-/number-is-nan-1.0.1.tgz",
-      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-      "dev": true
-    },
     "nwsapi": {
-      "version": "2.1.4",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/nwsapi/-/nwsapi-2.1.4.tgz",
-      "integrity": "sha1-4AaoeNsjY2+OimfTPKDk7fYahC8=",
+      "version": "2.2.0",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/nwsapi/-/nwsapi-2.2.0.tgz",
+      "integrity": "sha1-IEh5qePQaP8qVROcLHcngGgaOLc=",
       "dev": true
     },
     "oauth-sign": {
@@ -4656,6 +3874,12 @@
         }
       }
     },
+    "object-inspect": {
+      "version": "1.9.0",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/object-inspect/-/object-inspect-1.9.0.tgz",
+      "integrity": "sha1-yQUh104RJ7ZyZt7TOUrWEWmGUzo=",
+      "dev": true
+    },
     "object-keys": {
       "version": "1.1.1",
       "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/object-keys/-/object-keys-1.1.1.tgz",
@@ -4672,37 +3896,38 @@
       }
     },
     "object.assign": {
-      "version": "4.1.0",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/object.assign/-/object.assign-4.1.0.tgz",
-      "integrity": "sha1-lovxEA15Vrs8oIbwBvhGs7xACNo=",
+      "version": "4.1.2",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/object.assign/-/object.assign-4.1.2.tgz",
+      "integrity": "sha1-DtVKNC7Os3s4/3brgxoOeIy2OUA=",
       "dev": true,
       "requires": {
-        "define-properties": "^1.1.2",
-        "function-bind": "^1.1.1",
-        "has-symbols": "^1.0.0",
-        "object-keys": "^1.0.11"
+        "call-bind": "^1.0.0",
+        "define-properties": "^1.1.3",
+        "has-symbols": "^1.0.1",
+        "object-keys": "^1.1.1"
       }
     },
     "object.entries": {
-      "version": "1.1.0",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/object.entries/-/object.entries-1.1.0.tgz",
-      "integrity": "sha1-ICT8bWuiRq7ji9sP/Vz7zzcbdRk=",
+      "version": "1.1.3",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/object.entries/-/object.entries-1.1.3.tgz",
+      "integrity": "sha1-xgHH8Wi2I3RUGgfdvT4tXk93EaY=",
       "dev": true,
       "requires": {
+        "call-bind": "^1.0.0",
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.12.0",
-        "function-bind": "^1.1.1",
+        "es-abstract": "^1.18.0-next.1",
         "has": "^1.0.3"
       }
     },
     "object.getownpropertydescriptors": {
-      "version": "2.0.3",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
-      "integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
+      "version": "2.1.2",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.2.tgz",
+      "integrity": "sha1-G9Y66s8NXS0vMbXjk7A6fGAaI/c=",
       "dev": true,
       "requires": {
-        "define-properties": "^1.1.2",
-        "es-abstract": "^1.5.1"
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.18.0-next.2"
       }
     },
     "object.pick": {
@@ -4712,6 +3937,18 @@
       "dev": true,
       "requires": {
         "isobject": "^3.0.1"
+      }
+    },
+    "object.values": {
+      "version": "1.1.3",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/object.values/-/object.values-1.1.3.tgz",
+      "integrity": "sha1-6qix4XWJ8C9pjbCT98Yu4WmXQu4=",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.18.0-next.2",
+        "has": "^1.0.3"
       }
     },
     "once": {
@@ -4732,24 +3969,6 @@
         "mimic-fn": "^1.0.0"
       }
     },
-    "optimist": {
-      "version": "0.6.1",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/optimist/-/optimist-0.6.1.tgz",
-      "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
-      "dev": true,
-      "requires": {
-        "minimist": "~0.0.1",
-        "wordwrap": "~0.0.2"
-      },
-      "dependencies": {
-        "wordwrap": {
-          "version": "0.0.3",
-          "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/wordwrap/-/wordwrap-0.0.3.tgz",
-          "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
-          "dev": true
-        }
-      }
-    },
     "optionator": {
       "version": "0.8.2",
       "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/optionator/-/optionator-0.8.2.tgz",
@@ -4764,27 +3983,10 @@
         "wordwrap": "~1.0.0"
       }
     },
-    "os-locale": {
-      "version": "3.1.0",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/os-locale/-/os-locale-3.1.0.tgz",
-      "integrity": "sha1-qAKm7hfyTBBIOrmTVxnO9O0Wvxo=",
-      "dev": true,
-      "requires": {
-        "execa": "^1.0.0",
-        "lcid": "^2.0.0",
-        "mem": "^4.0.0"
-      }
-    },
     "os-tmpdir": {
       "version": "1.0.2",
       "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
-      "dev": true
-    },
-    "p-defer": {
-      "version": "1.0.0",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/p-defer/-/p-defer-1.0.0.tgz",
-      "integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=",
       "dev": true
     },
     "p-each-series": {
@@ -4800,12 +4002,6 @@
       "version": "1.0.0",
       "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/p-finally/-/p-finally-1.0.0.tgz",
       "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
-      "dev": true
-    },
-    "p-is-promise": {
-      "version": "2.1.0",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/p-is-promise/-/p-is-promise-2.1.0.tgz",
-      "integrity": "sha1-kYzrrqJIpiz3/6uOO8qMX4gvxC4=",
       "dev": true
     },
     "p-limit": {
@@ -4976,12 +4172,12 @@
       }
     },
     "pretty-format": {
-      "version": "24.8.0",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/pretty-format/-/pretty-format-24.8.0.tgz",
-      "integrity": "sha1-ja5wRPWNt8uL4kU4O1Zalj48J/I=",
+      "version": "24.9.0",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/pretty-format/-/pretty-format-24.9.0.tgz",
+      "integrity": "sha1-EvrDGzcBmk7qPBGqmpWet2KKp8k=",
       "dev": true,
       "requires": {
-        "@jest/types": "^24.8.0",
+        "@jest/types": "^24.9.0",
         "ansi-regex": "^4.0.0",
         "ansi-styles": "^3.2.0",
         "react-is": "^16.8.4"
@@ -4995,12 +4191,6 @@
         }
       }
     },
-    "process-nextick-args": {
-      "version": "2.0.1",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha1-eCDZsWEgzFXKmud5JoCufbptf+I=",
-      "dev": true
-    },
     "progress": {
       "version": "2.0.3",
       "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/progress/-/progress-2.0.3.tgz",
@@ -5008,13 +4198,13 @@
       "dev": true
     },
     "prompts": {
-      "version": "2.1.0",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/prompts/-/prompts-2.1.0.tgz",
-      "integrity": "sha1-v5C8cfYGXSVeor3A/mUgSFwbRds=",
+      "version": "2.4.0",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/prompts/-/prompts-2.4.0.tgz",
+      "integrity": "sha1-SqXeByOiMdHukSHED99mPfc/Ydc=",
       "dev": true,
       "requires": {
-        "kleur": "^3.0.2",
-        "sisteransi": "^1.0.0"
+        "kleur": "^3.0.3",
+        "sisteransi": "^1.0.5"
       }
     },
     "propagate": {
@@ -5023,9 +4213,9 @@
       "integrity": "sha1-AMLa7t2iDofjeCs0Stuhzd1q1wk="
     },
     "psl": {
-      "version": "1.1.33",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/psl/-/psl-1.1.33.tgz",
-      "integrity": "sha1-VTPZOEynqrhkJRmOEOgFPr/qtmE=",
+      "version": "1.8.0",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/psl/-/psl-1.8.0.tgz",
+      "integrity": "sha1-kyb4vPsBOtzABf3/BWrM4CDlHCQ=",
       "dev": true
     },
     "pump": {
@@ -5050,9 +4240,9 @@
       "integrity": "sha1-yzroBuh0BERYTvFUzo7pjUA/PjY="
     },
     "react-is": {
-      "version": "16.8.6",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/react-is/-/react-is-16.8.6.tgz",
-      "integrity": "sha1-W7weLSkUHJ+9/tRWND/ivEMKahY=",
+      "version": "16.13.1",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha1-eJcppNw23imZ3BVt1sHZwYzqVqQ=",
       "dev": true
     },
     "read-pkg": {
@@ -5074,21 +4264,6 @@
       "requires": {
         "find-up": "^2.0.0",
         "read-pkg": "^2.0.0"
-      }
-    },
-    "readable-stream": {
-      "version": "2.3.6",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/readable-stream/-/readable-stream-2.3.6.tgz",
-      "integrity": "sha1-sRwn2IuP8fvgcGQ8+UsMea4bCq8=",
-      "dev": true,
-      "requires": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
       }
     },
     "realpath-native": {
@@ -5135,9 +4310,9 @@
       "dev": true
     },
     "request": {
-      "version": "2.88.0",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/request/-/request-2.88.0.tgz",
-      "integrity": "sha1-nC/KT301tZLv5Xx/ClXoEFIST+8=",
+      "version": "2.88.2",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/request/-/request-2.88.2.tgz",
+      "integrity": "sha1-1zyRhzHLWofaBH4gcjQUb2ZNErM=",
       "dev": true,
       "requires": {
         "aws-sign2": "~0.7.0",
@@ -5147,7 +4322,7 @@
         "extend": "~3.0.2",
         "forever-agent": "~0.6.1",
         "form-data": "~2.3.2",
-        "har-validator": "~5.1.0",
+        "har-validator": "~5.1.3",
         "http-signature": "~1.2.0",
         "is-typedarray": "~1.0.0",
         "isstream": "~0.1.2",
@@ -5157,45 +4332,27 @@
         "performance-now": "^2.1.0",
         "qs": "~6.5.2",
         "safe-buffer": "^5.1.2",
-        "tough-cookie": "~2.4.3",
+        "tough-cookie": "~2.5.0",
         "tunnel-agent": "^0.6.0",
         "uuid": "^3.3.2"
-      },
-      "dependencies": {
-        "punycode": {
-          "version": "1.4.1",
-          "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/punycode/-/punycode-1.4.1.tgz",
-          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
-          "dev": true
-        },
-        "tough-cookie": {
-          "version": "2.4.3",
-          "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/tough-cookie/-/tough-cookie-2.4.3.tgz",
-          "integrity": "sha1-U/Nto/R3g7CSWvoG/587FlKA94E=",
-          "dev": true,
-          "requires": {
-            "psl": "^1.1.24",
-            "punycode": "^1.4.1"
-          }
-        }
       }
     },
     "request-promise-core": {
-      "version": "1.1.2",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/request-promise-core/-/request-promise-core-1.1.2.tgz",
-      "integrity": "sha1-M59qq6vK/bMceZ/xWHADNjAdM0Y=",
+      "version": "1.1.4",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/request-promise-core/-/request-promise-core-1.1.4.tgz",
+      "integrity": "sha1-Pu3UIjII1BmGe3jOgVFn0QWToi8=",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.11"
+        "lodash": "^4.17.19"
       }
     },
     "request-promise-native": {
-      "version": "1.0.7",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/request-promise-native/-/request-promise-native-1.0.7.tgz",
-      "integrity": "sha1-pJhopiS96lBp8SUdCoNuDYmqLFk=",
+      "version": "1.0.9",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/request-promise-native/-/request-promise-native-1.0.9.tgz",
+      "integrity": "sha1-5AcSBSal79yaObKKVnm/R7nZ3Cg=",
       "dev": true,
       "requires": {
-        "request-promise-core": "1.1.2",
+        "request-promise-core": "1.1.4",
         "stealthy-require": "^1.1.1",
         "tough-cookie": "^2.3.3"
       }
@@ -5213,11 +4370,12 @@
       "dev": true
     },
     "resolve": {
-      "version": "1.11.1",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/resolve/-/resolve-1.11.1.tgz",
-      "integrity": "sha1-6hDYEQN2mC/vV434/DC5rDCgej4=",
+      "version": "1.20.0",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/resolve/-/resolve-1.20.0.tgz",
+      "integrity": "sha1-YpoBP7P3B1XW8LeTXMHCxTeLGXU=",
       "dev": true,
       "requires": {
+        "is-core-module": "^2.2.0",
         "path-parse": "^1.0.6"
       }
     },
@@ -5335,14 +4493,6 @@
         "micromatch": "^3.1.4",
         "minimist": "^1.1.1",
         "walker": "~1.0.5"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-          "dev": true
-        }
       }
     },
     "sax": {
@@ -5363,9 +4513,9 @@
       "dev": true
     },
     "set-value": {
-      "version": "2.0.0",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/set-value/-/set-value-2.0.0.tgz",
-      "integrity": "sha1-ca5KiPD+77v1LR6mBPP7MV67YnQ=",
+      "version": "2.0.1",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/set-value/-/set-value-2.0.1.tgz",
+      "integrity": "sha1-oY1AUw5vB95CKMfe/kInr4ytAFs=",
       "dev": true,
       "requires": {
         "extend-shallow": "^2.0.1",
@@ -5413,9 +4563,9 @@
       "dev": true
     },
     "sisteransi": {
-      "version": "1.0.0",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/sisteransi/-/sisteransi-1.0.0.tgz",
-      "integrity": "sha1-d9liL/kJCA8cGeX0od8MGwonuIw=",
+      "version": "1.0.5",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/sisteransi/-/sisteransi-1.0.5.tgz",
+      "integrity": "sha1-E01oEpd1ZDfMBcoBNw06elcQde0=",
       "dev": true
     },
     "slash": {
@@ -5451,15 +4601,6 @@
         "use": "^3.1.0"
       },
       "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
         "define-property": {
           "version": "0.2.5",
           "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/define-property/-/define-property-0.2.5.tgz",
@@ -5478,10 +4619,10 @@
             "is-extendable": "^0.1.0"
           }
         },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
           "dev": true
         }
       }
@@ -5558,18 +4699,18 @@
       }
     },
     "source-map": {
-      "version": "0.5.7",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+      "version": "0.6.1",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
       "dev": true
     },
     "source-map-resolve": {
-      "version": "0.5.2",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
-      "integrity": "sha1-cuLMNAlVQ+Q7LGKyxMENSpBU8lk=",
+      "version": "0.5.3",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/source-map-resolve/-/source-map-resolve-0.5.3.tgz",
+      "integrity": "sha1-GQhmvs51U+H48mei7oLGBrVQmho=",
       "dev": true,
       "requires": {
-        "atob": "^2.1.1",
+        "atob": "^2.1.2",
         "decode-uri-component": "^0.2.0",
         "resolve-url": "^0.2.1",
         "source-map-url": "^0.4.0",
@@ -5577,33 +4718,25 @@
       }
     },
     "source-map-support": {
-      "version": "0.5.12",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/source-map-support/-/source-map-support-0.5.12.tgz",
-      "integrity": "sha1-tPOxDVGFelrwE4086AA7IBYT1Zk=",
+      "version": "0.5.19",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/source-map-support/-/source-map-support-0.5.19.tgz",
+      "integrity": "sha1-qYti+G3K9PZzmWSMCFKRq56P7WE=",
       "dev": true,
       "requires": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
-          "dev": true
-        }
       }
     },
     "source-map-url": {
-      "version": "0.4.0",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/source-map-url/-/source-map-url-0.4.0.tgz",
-      "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
+      "version": "0.4.1",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/source-map-url/-/source-map-url-0.4.1.tgz",
+      "integrity": "sha1-CvZmBadFpaL5HPG7+KevvCg97FY=",
       "dev": true
     },
     "spdx-correct": {
-      "version": "3.1.0",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/spdx-correct/-/spdx-correct-3.1.0.tgz",
-      "integrity": "sha1-+4PlBERSaPFUsHTiGMh8ADzTHfQ=",
+      "version": "3.1.1",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/spdx-correct/-/spdx-correct-3.1.1.tgz",
+      "integrity": "sha1-3s6BrJweZxPl99G28X1Gj6U9iak=",
       "dev": true,
       "requires": {
         "spdx-expression-parse": "^3.0.0",
@@ -5611,15 +4744,15 @@
       }
     },
     "spdx-exceptions": {
-      "version": "2.2.0",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
-      "integrity": "sha1-LqRQrudPKom/uUUZwH/Nb0EyKXc=",
+      "version": "2.3.0",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
+      "integrity": "sha1-PyjOGnegA3JoPq3kpDMYNSeiFj0=",
       "dev": true
     },
     "spdx-expression-parse": {
-      "version": "3.0.0",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
-      "integrity": "sha1-meEZt6XaAOBUkcn6M4t5BII7QdA=",
+      "version": "3.0.1",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+      "integrity": "sha1-z3D1BILu/cmOPOCmgz5KU87rpnk=",
       "dev": true,
       "requires": {
         "spdx-exceptions": "^2.1.0",
@@ -5627,9 +4760,9 @@
       }
     },
     "spdx-license-ids": {
-      "version": "3.0.4",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/spdx-license-ids/-/spdx-license-ids-3.0.4.tgz",
-      "integrity": "sha1-dezRqI3owYTvAV6vtRtbSL/RG7E=",
+      "version": "3.0.7",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/spdx-license-ids/-/spdx-license-ids-3.0.7.tgz",
+      "integrity": "sha1-6cGKQQ5e1+EkQqVJ+9ivp2cDjWU=",
       "dev": true
     },
     "split-string": {
@@ -5665,10 +4798,21 @@
       }
     },
     "stack-utils": {
-      "version": "1.0.2",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/stack-utils/-/stack-utils-1.0.2.tgz",
-      "integrity": "sha1-M+ujiXeIVYvr/C2wWdwVjsNs67g=",
-      "dev": true
+      "version": "1.0.4",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/stack-utils/-/stack-utils-1.0.4.tgz",
+      "integrity": "sha1-S2AJcdz8au0MvfKoJoF3zJFsh8g=",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "^2.0.0"
+      },
+      "dependencies": {
+        "escape-string-regexp": {
+          "version": "2.0.0",
+          "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+          "integrity": "sha1-owME6Z2qMuI7L9IPUbq9B8/8o0Q=",
+          "dev": true
+        }
+      }
     },
     "static-extend": {
       "version": "0.1.2",
@@ -5717,13 +4861,24 @@
         "strip-ansi": "^4.0.0"
       }
     },
-    "string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
+    "string.prototype.trimend": {
+      "version": "1.0.4",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
+      "integrity": "sha1-51rpDClCxjUEaGwYsoe0oLGkX4A=",
       "dev": true,
       "requires": {
-        "safe-buffer": "~5.1.0"
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3"
+      }
+    },
+    "string.prototype.trimstart": {
+      "version": "1.0.4",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
+      "integrity": "sha1-s2OZr0qymZtMnGSL16P7K7Jv7u0=",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3"
       }
     },
     "strip-ansi": {
@@ -5852,9 +5007,9 @@
           }
         },
         "p-limit": {
-          "version": "2.2.0",
-          "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/p-limit/-/p-limit-2.2.0.tgz",
-          "integrity": "sha1-QXyZQeYCepq8ulCS3SkE4lW1+8I=",
+          "version": "2.3.0",
+          "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/p-limit/-/p-limit-2.3.0.tgz",
+          "integrity": "sha1-PdM8ZHohT9//2DWTPrCG2g3CHbE=",
           "dev": true,
           "requires": {
             "p-try": "^2.0.0"
@@ -6023,11 +5178,17 @@
         "punycode": "^2.1.0"
       }
     },
-    "trim-right": {
-      "version": "1.0.1",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/trim-right/-/trim-right-1.0.1.tgz",
-      "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
-      "dev": true
+    "tsconfig-paths": {
+      "version": "3.9.0",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/tsconfig-paths/-/tsconfig-paths-3.9.0.tgz",
+      "integrity": "sha1-CYVHpsREiAfo/Ljq4IEGTumjyQs=",
+      "dev": true,
+      "requires": {
+        "@types/json5": "^0.0.29",
+        "json5": "^1.0.1",
+        "minimist": "^1.2.0",
+        "strip-bom": "^3.0.0"
+      }
     },
     "tslib": {
       "version": "1.10.0",
@@ -6064,59 +5225,28 @@
       "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/type-detect/-/type-detect-4.0.8.tgz",
       "integrity": "sha1-dkb7XxiHHPu3dJ5pvTmmOI63RQw="
     },
-    "uglify-js": {
-      "version": "3.6.0",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/uglify-js/-/uglify-js-3.6.0.tgz",
-      "integrity": "sha1-cEaBNFxTqLIHn7bOwpSwXq0kL/U=",
+    "unbox-primitive": {
+      "version": "1.0.0",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/unbox-primitive/-/unbox-primitive-1.0.0.tgz",
+      "integrity": "sha1-7qy8Sv+ijps9NrXq7MxQsyUbHT8=",
       "dev": true,
-      "optional": true,
       "requires": {
-        "commander": "~2.20.0",
-        "source-map": "~0.6.1"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
-          "dev": true,
-          "optional": true
-        }
+        "function-bind": "^1.1.1",
+        "has-bigints": "^1.0.0",
+        "has-symbols": "^1.0.0",
+        "which-boxed-primitive": "^1.0.1"
       }
     },
     "union-value": {
-      "version": "1.0.0",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/union-value/-/union-value-1.0.0.tgz",
-      "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
+      "version": "1.0.1",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/union-value/-/union-value-1.0.1.tgz",
+      "integrity": "sha1-C2/nuDWuzaYcbqTU8CwUIh4QmEc=",
       "dev": true,
       "requires": {
         "arr-union": "^3.1.0",
         "get-value": "^2.0.6",
         "is-extendable": "^0.1.1",
-        "set-value": "^0.4.3"
-      },
-      "dependencies": {
-        "extend-shallow": {
-          "version": "2.0.1",
-          "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
-          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-          "dev": true,
-          "requires": {
-            "is-extendable": "^0.1.0"
-          }
-        },
-        "set-value": {
-          "version": "0.4.3",
-          "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/set-value/-/set-value-0.4.3.tgz",
-          "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
-          "dev": true,
-          "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-extendable": "^0.1.1",
-            "is-plain-object": "^2.0.1",
-            "to-object-path": "^0.3.0"
-          }
-        }
+        "set-value": "^2.0.1"
       }
     },
     "unset-value": {
@@ -6180,26 +5310,23 @@
       "integrity": "sha1-1QyMrHmhn7wg8pEfVuuXP04QBw8=",
       "dev": true
     },
-    "util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-      "dev": true
-    },
     "util.promisify": {
-      "version": "1.0.0",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/util.promisify/-/util.promisify-1.0.0.tgz",
-      "integrity": "sha1-RA9xZaRZyaFtwUXrjnLzVocJcDA=",
+      "version": "1.1.1",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/util.promisify/-/util.promisify-1.1.1.tgz",
+      "integrity": "sha1-d4MvV87SyUeBdBScrpuW6ZGM1Us=",
       "dev": true,
       "requires": {
-        "define-properties": "^1.1.2",
-        "object.getownpropertydescriptors": "^2.0.3"
+        "call-bind": "^1.0.0",
+        "define-properties": "^1.1.3",
+        "for-each": "^0.3.3",
+        "has-symbols": "^1.0.1",
+        "object.getownpropertydescriptors": "^2.1.1"
       }
     },
     "uuid": {
-      "version": "3.3.2",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/uuid/-/uuid-3.3.2.tgz",
-      "integrity": "sha1-G0r0lV6zB3xQHCOHL8ZROBFYcTE=",
+      "version": "3.4.0",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha1-sj5DWK+oogL+ehAK8fX4g/AgB+4=",
       "dev": true
     },
     "validate-npm-package-license": {
@@ -6224,12 +5351,12 @@
       }
     },
     "w3c-hr-time": {
-      "version": "1.0.1",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/w3c-hr-time/-/w3c-hr-time-1.0.1.tgz",
-      "integrity": "sha1-gqwr/2PZUOqeMYmlimViX+3xkEU=",
+      "version": "1.0.2",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/w3c-hr-time/-/w3c-hr-time-1.0.2.tgz",
+      "integrity": "sha1-ConN9cwVgi35w2BUNnaWPgzDCM0=",
       "dev": true,
       "requires": {
-        "browser-process-hrtime": "^0.1.2"
+        "browser-process-hrtime": "^1.0.0"
       }
     },
     "walker": {
@@ -6282,6 +5409,19 @@
         "isexe": "^2.0.0"
       }
     },
+    "which-boxed-primitive": {
+      "version": "1.0.2",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
+      "integrity": "sha1-E3V7yJsgmwSf5dhkMOIc9AqJqOY=",
+      "dev": true,
+      "requires": {
+        "is-bigint": "^1.0.1",
+        "is-boolean-object": "^1.1.0",
+        "is-number-object": "^1.0.4",
+        "is-string": "^1.0.5",
+        "is-symbol": "^1.0.3"
+      }
+    },
     "which-module": {
       "version": "2.0.0",
       "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/which-module/-/which-module-2.0.0.tgz",
@@ -6295,48 +5435,40 @@
       "dev": true
     },
     "wrap-ansi": {
-      "version": "2.1.0",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
-      "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+      "version": "5.1.0",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+      "integrity": "sha1-H9H2cjXVttD+54EFYAG/tpTAOwk=",
       "dev": true,
       "requires": {
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1"
+        "ansi-styles": "^3.2.0",
+        "string-width": "^3.0.0",
+        "strip-ansi": "^5.0.0"
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "version": "4.1.0",
+          "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha1-i5+PCM8ay4Q3Vqg5yox+MWjFGZc=",
           "dev": true
         },
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "dev": true,
-          "requires": {
-            "number-is-nan": "^1.0.0"
-          }
-        },
         "string-width": {
-          "version": "1.0.2",
-          "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/string-width/-/string-width-1.0.2.tgz",
-          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "version": "3.1.0",
+          "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha1-InZ74htirxCBV0MG9prFG2IgOWE=",
           "dev": true,
           "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
           }
         },
         "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "version": "5.2.0",
+          "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha1-jJpTb+tq/JYr36WxBKUJHBrZwK4=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^2.0.0"
+            "ansi-regex": "^4.1.0"
           }
         }
       }
@@ -6383,31 +5515,35 @@
       "dev": true
     },
     "y18n": {
-      "version": "4.0.0",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/y18n/-/y18n-4.0.0.tgz",
-      "integrity": "sha1-le+U+F7MgdAHwmThkKEg8KPIVms=",
+      "version": "4.0.1",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/y18n/-/y18n-4.0.1.tgz",
+      "integrity": "sha1-jbK4PDHF11CZu4kLI/MJSJHiR9Q=",
       "dev": true
     },
     "yargs": {
-      "version": "12.0.5",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/yargs/-/yargs-12.0.5.tgz",
-      "integrity": "sha1-BfWZe2CWR7ZPZrgeO0sQo2jnrRM=",
+      "version": "13.3.2",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/yargs/-/yargs-13.3.2.tgz",
+      "integrity": "sha1-rX/+/sGqWVZayRX4Lcyzipwxot0=",
       "dev": true,
       "requires": {
-        "cliui": "^4.0.0",
-        "decamelize": "^1.2.0",
+        "cliui": "^5.0.0",
         "find-up": "^3.0.0",
-        "get-caller-file": "^1.0.1",
-        "os-locale": "^3.0.0",
+        "get-caller-file": "^2.0.1",
         "require-directory": "^2.1.1",
-        "require-main-filename": "^1.0.1",
+        "require-main-filename": "^2.0.0",
         "set-blocking": "^2.0.0",
-        "string-width": "^2.0.0",
+        "string-width": "^3.0.0",
         "which-module": "^2.0.0",
-        "y18n": "^3.2.1 || ^4.0.0",
-        "yargs-parser": "^11.1.1"
+        "y18n": "^4.0.0",
+        "yargs-parser": "^13.1.2"
       },
       "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha1-i5+PCM8ay4Q3Vqg5yox+MWjFGZc=",
+          "dev": true
+        },
         "find-up": {
           "version": "3.0.0",
           "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/find-up/-/find-up-3.0.0.tgz",
@@ -6428,9 +5564,9 @@
           }
         },
         "p-limit": {
-          "version": "2.2.0",
-          "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/p-limit/-/p-limit-2.2.0.tgz",
-          "integrity": "sha1-QXyZQeYCepq8ulCS3SkE4lW1+8I=",
+          "version": "2.3.0",
+          "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/p-limit/-/p-limit-2.3.0.tgz",
+          "integrity": "sha1-PdM8ZHohT9//2DWTPrCG2g3CHbE=",
           "dev": true,
           "requires": {
             "p-try": "^2.0.0"
@@ -6451,18 +5587,32 @@
           "integrity": "sha1-yyhoVA4xPWHeWPr741zpAE1VQOY=",
           "dev": true
         },
-        "require-main-filename": {
-          "version": "1.0.1",
-          "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/require-main-filename/-/require-main-filename-1.0.1.tgz",
-          "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
-          "dev": true
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha1-InZ74htirxCBV0MG9prFG2IgOWE=",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha1-jJpTb+tq/JYr36WxBKUJHBrZwK4=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
         }
       }
     },
     "yargs-parser": {
-      "version": "11.1.1",
-      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/yargs-parser/-/yargs-parser-11.1.1.tgz",
-      "integrity": "sha1-h5oIZZc7yp9rq1y987HGfsfTvPQ=",
+      "version": "13.1.2",
+      "resolved": "https://artifactory.nerdwallet.io/artifactory/api/npm/npm/yargs-parser/-/yargs-parser-13.1.2.tgz",
+      "integrity": "sha1-Ew8JcC667vJlDVTObj5XBvek+zg=",
       "dev": true,
       "requires": {
         "camelcase": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -20,18 +20,18 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "lodash": "^4.17.11",
-    "mkdirp": "^0.5.1",
+    "lodash": "^4.17.21",
+    "mkdirp": "^0.5.5",
     "nock": "^10.0.6"
   },
   "devDependencies": {
     "eslint": "^5.16.0",
-    "eslint-config-airbnb-base": "^13.1.0",
+    "eslint-config-airbnb-base": "^13.2.0",
     "eslint-config-prettier": "^4.1.0",
-    "eslint-plugin-import": "^2.17.1",
-    "eslint-plugin-prettier": "^3.0.1",
-    "jest": "^24.8.0",
-    "node-fetch": "^2.6.0",
+    "eslint-plugin-import": "^2.22.1",
+    "eslint-plugin-prettier": "^3.3.1",
+    "jest": "^24.9.0",
+    "node-fetch": "^2.6.1",
     "prettier": "1.17.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.1.0",
+  "version": "1.1.1",
   "name": "@nerdwallet/jest-nock-fixtures",
   "description": "jest-nock-fixtures",
   "author": "benjroy <ballen@nerdwallet.com>",


### PR DESCRIPTION
## 1.1.1 (2021-03-23) benjroy

- run `npm update` and `npm audit fix` to clear security warning from dependencies

closes https://github.com/NerdWalletOSS/jest-nock-fixtures/pull/7
closes https://github.com/NerdWalletOSS/jest-nock-fixtures/pull/9
closes https://github.com/NerdWalletOSS/jest-nock-fixtures/pull/10
closes https://github.com/NerdWalletOSS/jest-nock-fixtures/pull/11
closes https://github.com/NerdWalletOSS/jest-nock-fixtures/pull/13
