### PR TITLE
Move many logs behind verbose flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ jest-nock-fixtures is a wrapper for a jest testing environment. It uses `nock` t
 npm install @nerdwallet/jest-nock-fixtures
 ```
 
-## Setup
+## Setup and usage
 
 Configure `jest` to setup this wrapper before the tests in each test file are executed.  In `jest@24`, this can be achieved by configuring `setupFilesAfterEnv` (https://jestjs.io/docs/en/configuration#setupfilesafterenv-array)
 
@@ -58,7 +58,7 @@ then configure jest to activate `@nerdwallet/jest-nock-fixtures` and wrap each t
 }
 ```
 
-#### Modes
+### Modes
 
 Available modes:
 - `dryrun`: The default, use recorded nocks, allow new http calls, doesn't record anything, useful for writing new tests
@@ -93,6 +93,14 @@ npm run test:record
 # commit and push the added/changed `__nocks__/*.json` fixture files
 
 # and then in CI enjoy peace of mind for consistent and reproducable test runs in the context of network requests
+```
+
+### Log levels
+
+By default, minimal logs will be printed. To increase the verbosity of the logs, set `JEST_NOCK_FIXTURES_VERBOSE` when running tests. For example:
+
+```sh
+JEST_NOCK_FIXTURES_VERBOSE=1 npm run test
 ```
 
 ## Developing

--- a/src/createNockFixturesTestWrapper.js
+++ b/src/createNockFixturesTestWrapper.js
@@ -93,7 +93,7 @@ function createNockFixturesTestWrapper(options = {}) {
   const log = str => console.log(message(str));
   const logVerbose = str => {
     if (!process.env.JEST_NOCK_FIXTURES_VERBOSE) return;
-    log(grey(str));
+    log(str);
   };
 
   // ensure a valid mode is being used


### PR DESCRIPTION
This PR moves most of the logs behind a "verbose" flag - specifically, a `JEST_NOCK_FIXTURES_VERBOSE` environment variable. The logs were very noisy enough that it became difficult to pick out other logs during test runs and in general didn't provide valuable information.

We could have added a full system for different log levels, e.g. `JEST_NOCK_FIXTURES_LOG_LEVEL=verbose`. However, I don't think there's much value in that at this point.