### PR TITLE
Set registry URL for release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 16
+          registry-url: https://registry.npmjs.org/
       - name: Get Yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn cache dir)"


### PR DESCRIPTION
According to https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages and https://github.com/actions/setup-node/issues/81, this is necessary to properly configure credentials.